### PR TITLE
Fixed maven search link

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ public fun testCreate() {
 
 ## Binaries
 
-Binaries and dependency information for Maven, Ivy, Gradle and others can be found at [http://search.maven.org](http://search.maven.org/#search%7Cga%7C1%7Ca%3A%22rxjava-kotlin%22).
+Binaries and dependency information for Maven, Ivy, Gradle and others can be found at [http://search.maven.org](http://search.maven.org/#search%7Cga%7C1%7Crxkotlin).
 
 Example for Maven:
 


### PR DESCRIPTION
The old link was pointing to RxJava-Kotlin, updated to RxKotlin, maven search link now provides the correct version.
