### PR TITLE
Extensions post-merge fixes

### DIFF
--- a/src/main/kotlin/rx/lang/kotlin/observables.kt
+++ b/src/main/kotlin/rx/lang/kotlin/observables.kt
@@ -80,7 +80,7 @@ public fun <T : Any> Observable<T?>.filterNotNull() : Observable<T> = lift { s -
  */
 public fun <T> Observable<T>.withIndex() : Observable<IndexedValue<T>> = lift { s ->
     var index = 0
-    listOf(1).withIndex()
+
     subscriber<T>().
             onNext { v -> s.onNext(IndexedValue(index++, v)) }.
             onCompleted { s.onCompleted() }.

--- a/src/main/kotlin/rx/lang/kotlin/subscribers.kt
+++ b/src/main/kotlin/rx/lang/kotlin/subscribers.kt
@@ -2,11 +2,13 @@ package rx.lang.kotlin
 
 import rx.Subscriber
 import rx.observers.SerializedSubscriber
+import rx.exceptions.OnErrorNotImplementedException
 
-public class FunctionSubscriber<T>(onCompletedFunction: () -> Unit, onErrorFunction: (e : Throwable) -> Unit, onNextFunction: (value : T) -> Unit) : Subscriber<T>() {
+public class FunctionSubscriber<T>(onCompletedFunction: () -> Unit, onErrorFunction: (e : Throwable) -> Unit, onNextFunction: (value : T) -> Unit, onStartFunction : () -> Unit) : Subscriber<T>() {
     private val onCompletedFunction: () -> Unit = onCompletedFunction
     private val onErrorFunction: (e : Throwable) -> Unit = onErrorFunction
     private val onNextFunction: (value : T) -> Unit = onNextFunction
+    private val onStartFunction : () -> Unit = onStartFunction
 
     override fun onCompleted() = onCompletedFunction()
 
@@ -14,10 +16,13 @@ public class FunctionSubscriber<T>(onCompletedFunction: () -> Unit, onErrorFunct
 
     override fun onNext(t: T) = onNextFunction(t)
 
-    fun onCompleted(onCompletedFunction: () -> Unit) : FunctionSubscriber<T> = FunctionSubscriber(onCompletedFunction, this.onErrorFunction, this.onNextFunction)
-    fun onError(onErrorFunction: (t : Throwable) -> Unit) : FunctionSubscriber<T> = FunctionSubscriber(this.onCompletedFunction, onErrorFunction, this.onNextFunction)
-    fun onNext(onNextFunction: (t : T) -> Unit) : FunctionSubscriber<T> = FunctionSubscriber(this.onCompletedFunction, this.onErrorFunction, onNextFunction)
+    override fun onStart() = onStartFunction()
+
+    fun onCompleted(onCompletedFunction: () -> Unit) : FunctionSubscriber<T> = FunctionSubscriber(onCompletedFunction, this.onErrorFunction, this.onNextFunction, this.onStartFunction)
+    fun onError(onErrorFunction: (t : Throwable) -> Unit) : FunctionSubscriber<T> = FunctionSubscriber(this.onCompletedFunction, onErrorFunction, this.onNextFunction, this.onStartFunction)
+    fun onNext(onNextFunction: (t : T) -> Unit) : FunctionSubscriber<T> = FunctionSubscriber(this.onCompletedFunction, this.onErrorFunction, onNextFunction, this.onStartFunction)
+    fun onStart(onStartFunction : () -> Unit) : FunctionSubscriber<T> = FunctionSubscriber(this.onCompletedFunction, this.onErrorFunction, this.onNextFunction, onStartFunction)
 }
 
-public fun <T> subscriber(): FunctionSubscriber<T> = FunctionSubscriber({}, {}, {})
+public fun <T> subscriber(): FunctionSubscriber<T> = FunctionSubscriber({}, {throw OnErrorNotImplementedException(it)}, {}, {})
 public fun <T> Subscriber<T>.synchronized() : Subscriber<T>  = SerializedSubscriber(this)

--- a/src/test/kotlin/rx/lang/kotlin/SubscribersTest.kt
+++ b/src/test/kotlin/rx/lang/kotlin/SubscribersTest.kt
@@ -8,20 +8,20 @@ import kotlin.test.assertEquals
 public class SubscribersTest {
     test fun testEmptySubscriber() {
         val s = subscriber<Int>()
-        callSubscriberMethods(s)
+        callSubscriberMethods(false, s)
     }
 
     test fun testSubscriberConstruction() {
         val events = ArrayList<String>()
 
-        callSubscriberMethods(subscriber<Int>().
+        callSubscriberMethods(false, subscriber<Int>().
                 onNext {events.add("onNext($it)")}
         )
 
         assertEquals(listOf("onNext(1)"), events)
         events.clear()
 
-        callSubscriberMethods(subscriber<Int>().
+        callSubscriberMethods(true, subscriber<Int>().
                 onNext {events.add("onNext($it)")}.
                 onError { events.add(it.javaClass.getSimpleName()) }
         )
@@ -29,7 +29,7 @@ public class SubscribersTest {
         assertEquals(listOf("onNext(1)", "RuntimeException"), events)
         events.clear()
 
-        callSubscriberMethods(subscriber<Int>().
+        callSubscriberMethods(true, subscriber<Int>().
                 onNext {events.add("onNext($it)")}.
                 onError { events.add(it.javaClass.getSimpleName()) }.
                 onCompleted { events.add("onCompleted") }
@@ -39,9 +39,15 @@ public class SubscribersTest {
         events.clear()
     }
 
-    private fun callSubscriberMethods(s: Subscriber<Int>) {
+    private fun callSubscriberMethods(hasOnError : Boolean, s: Subscriber<Int>) {
         s.onNext(1)
-        s.onError(RuntimeException())
+        try {
+            s.onError(RuntimeException())
+        } catch (t : Throwable) {
+            if (hasOnError) {
+                throw t
+            }
+        }
         s.onCompleted()
     }
 }


### PR DESCRIPTION
FunctionSubscriber should throw OnErrorNotImplementedException as it does default implementation

It should be way to implement onStart() in FunctionSubscriber

Remove accidently added code
