### PR TITLE
Proposing Observable.subscribeWith { ... }

### DIFF
--- a/src/main/kotlin/rx/lang/kotlin/observables.kt
+++ b/src/main/kotlin/rx/lang/kotlin/observables.kt
@@ -2,6 +2,7 @@ package rx.lang.kotlin
 
 import rx.Observable
 import rx.Subscriber
+import rx.Subscription
 import rx.observables.BlockingObservable
 
 public fun <T> emptyObservable() : Observable<T> = Observable.empty()
@@ -96,3 +97,12 @@ public fun <T> Observable<T>.withIndex() : Observable<IndexedValue<T>> = lift { 
  *  @returns Observable that merges all [Sequence]s produced by [body] functions
  */
 public fun <T, R> Observable<T>.flatMapSequence( body : (T) -> Sequence<R> ) : Observable<R> = flatMap { body(it).toObservable() }
+
+/**
+ * Subscribe with a subscriber that is configured inside body
+ */
+public inline fun <T> Observable<T>.subscribeWith( body : FunctionSubscriberModifier<T>.() -> Unit ) : Subscription {
+    val modifier = FunctionSubscriberModifier(subscriber<T>())
+    modifier.body()
+    return subscribe(modifier.subscriber)
+}

--- a/src/main/kotlin/rx/lang/kotlin/subscribers.kt
+++ b/src/main/kotlin/rx/lang/kotlin/subscribers.kt
@@ -25,13 +25,13 @@ public class FunctionSubscriber<T>(onCompletedFunction: () -> Unit, onErrorFunct
 }
 
 public class FunctionSubscriberModifier<T>(init: FunctionSubscriber<T> = subscriber()) {
-    private var instance: FunctionSubscriber<T> = init
-    public val subscriber: FunctionSubscriber<T> get() = instance
+    public var subscriber: FunctionSubscriber<T> = init
+        private set
 
-    fun onCompleted(onCompletedFunction: () -> Unit) : Unit { instance = instance.onCompleted(onCompletedFunction) }
-    fun onError(onErrorFunction: (t : Throwable) -> Unit) : Unit { instance = instance.onError(onErrorFunction) }
-    fun onNext(onNextFunction: (t : T) -> Unit) : Unit { instance = instance.onNext(onNextFunction) }
-    fun onStart(onStartFunction : () -> Unit) : Unit { instance = instance.onStart(onStartFunction) }
+    fun onCompleted(onCompletedFunction: () -> Unit) : Unit { subscriber = subscriber.onCompleted(onCompletedFunction) }
+    fun onError(onErrorFunction: (t : Throwable) -> Unit) : Unit { subscriber = subscriber.onError(onErrorFunction) }
+    fun onNext(onNextFunction: (t : T) -> Unit) : Unit { subscriber = subscriber.onNext(onNextFunction) }
+    fun onStart(onStartFunction : () -> Unit) : Unit { subscriber = subscriber.onStart(onStartFunction) }
 }
 
 public fun <T> subscriber(): FunctionSubscriber<T> = FunctionSubscriber({}, {throw OnErrorNotImplementedException(it)}, {}, {})

--- a/src/main/kotlin/rx/lang/kotlin/subscribers.kt
+++ b/src/main/kotlin/rx/lang/kotlin/subscribers.kt
@@ -24,5 +24,15 @@ public class FunctionSubscriber<T>(onCompletedFunction: () -> Unit, onErrorFunct
     fun onStart(onStartFunction : () -> Unit) : FunctionSubscriber<T> = FunctionSubscriber(this.onCompletedFunction, this.onErrorFunction, this.onNextFunction, onStartFunction)
 }
 
+public class FunctionSubscriberModifier<T>(init: FunctionSubscriber<T> = subscriber()) {
+    private var instance: FunctionSubscriber<T> = init
+    public val subscriber: FunctionSubscriber<T> get() = instance
+
+    fun onCompleted(onCompletedFunction: () -> Unit) : Unit { instance = instance.onCompleted(onCompletedFunction) }
+    fun onError(onErrorFunction: (t : Throwable) -> Unit) : Unit { instance = instance.onError(onErrorFunction) }
+    fun onNext(onNextFunction: (t : T) -> Unit) : Unit { instance = instance.onNext(onNextFunction) }
+    fun onStart(onStartFunction : () -> Unit) : Unit { instance = instance.onStart(onStartFunction) }
+}
+
 public fun <T> subscriber(): FunctionSubscriber<T> = FunctionSubscriber({}, {throw OnErrorNotImplementedException(it)}, {}, {})
 public fun <T> Subscriber<T>.synchronized() : Subscriber<T>  = SerializedSubscriber(this)

--- a/src/test/kotlin/rx/lang/kotlin/SubscribersTest.kt
+++ b/src/test/kotlin/rx/lang/kotlin/SubscribersTest.kt
@@ -60,39 +60,36 @@ public class SubscribersTest {
 
         val events = ArrayList<String>()
 
-        val s1 = completeObservable.subscribeWith {
+        completeObservable.subscribeWith {
             onNext { events.add("onNext($it)") }
         }
 
         assertEquals(listOf("onNext(1)"), events)
         events.clear()
-        s1.unsubscribe()
 
-        val s2 = completeObservable.subscribeWith {
+        completeObservable.subscribeWith {
             onNext { events.add("onNext($it)") }
             onCompleted { events.add("onCompleted") }
         }
 
         assertEquals(listOf("onNext(1)", "onCompleted"), events)
         events.clear()
-        s2.unsubscribe()
 
         val errorObservable = observable<Int> {
             it.onNext(1)
             it.onError(RuntimeException())
         }
 
-        val s3 = errorObservable.subscribeWith {
+        errorObservable.subscribeWith {
             onNext { events.add("onNext($it)") }
             onError { events.add("onError(${it.javaClass.getSimpleName()})") }
         }
 
         assertEquals(listOf("onNext(1)", "onError(RuntimeException)"), events)
         events.clear()
-        s3.unsubscribe()
 
         try {
-            val s4 = errorObservable.subscribeWith {
+            errorObservable.subscribeWith {
                 onNext { events.add("onNext($it)") }
             }
         } catch (t: Throwable) {
@@ -101,7 +98,5 @@ public class SubscribersTest {
 
         assertEquals(listOf("onNext(1)", "catch(OnErrorNotImplementedException)"), events)
         events.clear()
-        s1.unsubscribe()
-
     }
 }


### PR DESCRIPTION
I find the current subscriber syntax cumbersome. Here's an example:

``` kotlin
myObservable.subscribe(subscriber<String>()
    .onNext { println(it) }
    .onError { it.printStackTrace() }
)
```

The problem I have is with `subscriber<String>()`. Because it creates a subscriber that is later modified with `.onNext` and `.onError`, the Kotlin compiler cannot infer it's type.  
For `subscriber<String>`, this is not such an issue, but for `subscriber<Map<String, User.Status>>` this can quickly become cumbersome.

Beside, we could better use Kotlin's amazing type inference system and use a more "Kotlin-esque" way.

This PR introduces a new way of subscribing to an observable with this proposed API:

``` kotlin
myObservable.subscribeWith {
    onNext { println(it) }
    onError { it.printStackTrace() }
}
```

The API is using Kotlin's [type-safe builder pattern](http://kotlinlang.org/docs/reference/type-safe-builders.html).

Let me know what you think ;)
