### PR TITLE
Add extension for more idiomatic subscription addition

### DIFF
--- a/src/main/kotlin/rx/lang/kotlin/subscribers.kt
+++ b/src/main/kotlin/rx/lang/kotlin/subscribers.kt
@@ -3,6 +3,7 @@ package rx.lang.kotlin
 import rx.Subscriber
 import rx.exceptions.OnErrorNotImplementedException
 import rx.observers.SerializedSubscriber
+import rx.subscriptions.Subscriptions
 import java.util.*
 
 class FunctionSubscriber<T>() : Subscriber<T>() {
@@ -55,3 +56,4 @@ class FunctionSubscriberModifier<T>(init: FunctionSubscriber<T> = subscriber()) 
 
 fun <T> subscriber(): FunctionSubscriber<T> = FunctionSubscriber()
 fun <T> Subscriber<T>.synchronized(): Subscriber<T> = SerializedSubscriber(this)
+fun Subscriber<*>.add(action: () -> Unit) = add(Subscriptions.create(action))

--- a/src/test/kotlin/rx/lang/kotlin/SubscribersTest.kt
+++ b/src/test/kotlin/rx/lang/kotlin/SubscribersTest.kt
@@ -134,4 +134,14 @@ class SubscribersTest {
         assertEquals(listOf("onNext(1)", "catch(OnErrorNotImplementedException)"), events)
         events.clear()
     }
+
+    @test fun testIdiomaticAdd() {
+        var subscriptionCalled = false
+        val s = subscriber<Int>()
+
+        s.add { subscriptionCalled = true }
+        s.unsubscribe()
+
+        assertTrue(subscriptionCalled)
+    }
 }


### PR DESCRIPTION
Hi, sorry for not contacting you before pushing and checking if you'd find such addition useful at all, but I had it ready, so I thought it would be best explained, when you could see the code.

It's just a simple extension for more idiomatic way of adding a subscription to a subscriber. Without it you have to write:

``` kotlin
subscriber.add(Subscriptions.create { context.unregisterReceiver(receiver) })
```

With it you get a nicer shorter:

``` kotlin
subscriber.add { context.unregisterReceiver(receiver) }
```

I've found it useful. I hope it makes sense for the direction you are taking with this library and it matches your standards. However, if it doesn't feel free to close without merging - I understand the need to not inflate library with code you don't find fitting.
