### PR TITLE
cast operator

### DIFF
--- a/src/main/kotlin/rx/lang/kotlin/observables.kt
+++ b/src/main/kotlin/rx/lang/kotlin/observables.kt
@@ -102,3 +102,8 @@ fun <T, R> List<Observable<T>>.combineLatest(combineFunction: (args: List<T>) ->
 @Suppress("UNCHECKED_CAST")
 fun <T, R> List<Observable<T>>.zip(zipFunction: (args: List<T>) -> R): Observable<R> =
         Observable.zip(this, { zipFunction(it.asList() as List<T>) })
+
+/**
+ * Returns an Observable that emits the items emitted by the source Observable, converted to the specified type.
+ */
+inline fun <reified R : Any> Observable<*>.cast(): Observable<R> = cast(R::class.java)

--- a/src/test/kotlin/rx/lang/kotlin/ObservablesTest.kt
+++ b/src/test/kotlin/rx/lang/kotlin/ObservablesTest.kt
@@ -151,4 +151,24 @@ class ObservablesTest {
         val list = listOf(1,2,3,2,3,4,3,4,5)
         assertEquals(list, list.map { it.toSingletonObservable() }.zip { it }.toBlocking().first())
     }
+
+    @test fun testCast() {
+        val source = Observable.just<Any>(1, 2)
+        val observable = source.cast<Int>()
+        val subscriber = TestSubscriber<Int>()
+        observable.subscribe(subscriber)
+        subscriber.apply {
+            assertValues(1, 2)
+            assertNoErrors()
+            assertCompleted()
+        }
+    }
+
+    @test fun testCastWithWrongType() {
+        val source = Observable.just<Any>(1, 2)
+        val observable = source.cast<String>()
+        val subscriber = TestSubscriber<Any>()
+        observable.subscribe(subscriber)
+        subscriber.assertError(ClassCastException::class.java)
+    }
 }


### PR DESCRIPTION
`cast(Foo::class.java)` becomes `cast<Foo>()`
