### PR TITLE
Add generic toSingle() extension function

### DIFF
--- a/src/main/kotlin/rx/lang/kotlin/single.kt
+++ b/src/main/kotlin/rx/lang/kotlin/single.kt
@@ -7,5 +7,6 @@ import java.util.concurrent.Future
 
 fun <T> single(body: (s: SingleSubscriber<in T>) -> Unit): Single<T> = Single.create(body)
 fun <T> singleOf(value: T): Single<T> = Single.just(value)
+fun <T> T.toSingle(): Single<T> = singleOf(this)
 fun <T> Future<T>.toSingle(): Single<T> = Single.from(this)
 fun <T> Callable<T>.toSingle(): Single<T> = Single.fromCallable { this.call() }

--- a/src/test/kotlin/rx/lang/kotlin/SingleTest.kt
+++ b/src/test/kotlin/rx/lang/kotlin/SingleTest.kt
@@ -43,4 +43,16 @@ class SingleTest : KotlinTests() {
         }
         Mockito.verify(a, Mockito.times(1)).received("Hello World!")
     }
+
+    @test fun testCreateFromGeneric() {
+        "Hello World!".toSingle().subscribe { result ->
+            a.received(result)
+        }
+        Mockito.verify(a, Mockito.times(1)).received("Hello World!")
+
+        1337.toSingle().subscribe { result ->
+            a.received(result)
+        }
+        Mockito.verify(a, Mockito.times(1)).received(1337)
+    }
 }


### PR DESCRIPTION
Adds a generic `toSingle()` extension function which is just a delegate to `singleOf()`.
