### PR TITLE
Add subscriptions directly to a CompositeSubscription

### DIFF
--- a/src/examples/kotlin/rx/lang/kotlin/examples/examples.kt
+++ b/src/examples/kotlin/rx/lang/kotlin/examples/examples.kt
@@ -5,6 +5,7 @@ import rx.lang.kotlin.*
 import rx.subscriptions.CompositeSubscription
 import java.net.URL
 import java.util.*
+import java.util.concurrent.TimeUnit
 import kotlin.concurrent.thread
 
 fun main(args: Array<String>) {
@@ -38,6 +39,8 @@ fun main(args: Array<String>) {
     simpleObservable().subscribe(FunctionSubscriber<String>()
             .onNext { s -> println("1st onNext => $s") }
             .onNext { s -> println("2nd onNext => $s") })
+
+    addToCompositeSubscription()
 }
 
 private fun URL.toScannerObservable() = observable<String> { s ->
@@ -99,3 +102,14 @@ fun zip(observables: List<Observable<String>>) {
 }
 
 fun simpleObservable(): Observable<String> = (0..17).toObservable().map { "Simple $it" }
+
+fun addToCompositeSubscription() {
+    val compositeSubscription = CompositeSubscription()
+
+    Observable.just("test")
+            .delay(100, TimeUnit.MILLISECONDS)
+            .subscribe()
+            .addTo(compositeSubscription)
+
+    compositeSubscription.unsubscribe()
+}

--- a/src/main/kotlin/rx/lang/kotlin/subscription.kt
+++ b/src/main/kotlin/rx/lang/kotlin/subscription.kt
@@ -7,3 +7,13 @@ import rx.subscriptions.CompositeSubscription
  * subscription += observable.subscribe{}
  */
 operator fun CompositeSubscription.plusAssign(subscription: Subscription) = add(subscription)
+
+/**
+ * Add the subscription to a CompositeSubscription.
+ * @param compositeSubscription CompositeSubscription to add this subscription to
+ * @return this instance
+ */
+fun Subscription.addTo(compositeSubscription: CompositeSubscription) : Subscription {
+    compositeSubscription.add(this)
+    return this
+}

--- a/src/test/kotlin/rx/lang/kotlin/SubscriptionTests.kt
+++ b/src/test/kotlin/rx/lang/kotlin/SubscriptionTests.kt
@@ -1,0 +1,29 @@
+package rx.lang.kotlin
+
+import org.junit.Test
+import rx.Observable
+import rx.subscriptions.CompositeSubscription
+import java.util.concurrent.TimeUnit
+
+class SubscriptionTest {
+    @Test fun testSubscriptionAddTo() {
+        val compositeSubscription = CompositeSubscription()
+
+        // Create an asynchronous subscription
+        // The delay ensures that we don't automatically unsubscribe because data finished emitting
+        val subscription = Observable.just("test")
+                .delay(100, TimeUnit.MILLISECONDS)
+                .subscribe();
+
+        assert(!subscription.isUnsubscribed)
+
+        subscription.addTo(compositeSubscription);
+
+        assert(compositeSubscription.hasSubscriptions());
+        assert(!subscription.isUnsubscribed);
+
+        compositeSubscription.unsubscribe()
+
+        assert(compositeSubscription.isUnsubscribed);
+    }
+}


### PR DESCRIPTION
This feature is inspired by RxSwift [DisposeBag](https://github.com/ReactiveX/RxSwift/blob/master/RxSwift/Disposables/DisposeBag.swift).

The idea is that you can add your `Subscription` directly (inline) to a `CompositeSubscription` rather than having it assigned to a separate `val` first and then manually adding it a `CompositeSubscription` after assignment.

Usage:

```
Observable.just("test")
        .delay(100, TimeUnit.MILLISECONDS)
        .subscribe()
        .addTo(compositeSubscription)
```

I chose the name `addTo()` so that other containers could be targeted in the future.
`addTo()` returns the original `Subscription` so that it could be called consecutively.

A practical usage would be the Android `Fragment` instances:
They have several important life cycle events such as "UI destroyed" and "Fragment destroyed". `Subscription` instances can be tied to these life cycle events through `CompositeSubscription` instances that are unsubscribed when the life cycle event happens.

I've created an example and added tests for this feature.
