### PR TITLE
added support for `ofType`

### DIFF
--- a/src/main/kotlin/rx/lang/kotlin/observables.kt
+++ b/src/main/kotlin/rx/lang/kotlin/observables.kt
@@ -107,3 +107,8 @@ fun <T, R> List<Observable<T>>.zip(zipFunction: (args: List<T>) -> R): Observabl
  * Returns an Observable that emits the items emitted by the source Observable, converted to the specified type.
  */
 inline fun <reified R : Any> Observable<*>.cast(): Observable<R> = cast(R::class.java)
+
+/**
+ * Filters the items emitted by an Observable, only emitting those of the specified type.
+ */
+inline fun <reified R : Any> Observable<*>.ofType(): Observable<R> = ofType(R::class.java)

--- a/src/test/kotlin/rx/lang/kotlin/ObservablesTest.kt
+++ b/src/test/kotlin/rx/lang/kotlin/ObservablesTest.kt
@@ -4,6 +4,7 @@ import org.junit.Assert.*
 import org.junit.Ignore
 import rx.Observable
 import rx.observers.TestSubscriber
+import java.math.BigDecimal
 import java.util.concurrent.atomic.AtomicInteger
 import org.junit.Test as test
 
@@ -170,5 +171,43 @@ class ObservablesTest {
         val subscriber = TestSubscriber<Any>()
         observable.subscribe(subscriber)
         subscriber.assertError(ClassCastException::class.java)
+    }
+
+    @test fun testOfType() {
+        val source = Observable.just<Number>(BigDecimal.valueOf(15, 1), 2, BigDecimal.valueOf(42), 15)
+
+        val intSubscriber = TestSubscriber<Int>()
+        val bigDecimalSubscriber = TestSubscriber<BigDecimal>()
+        val doubleSubscriber = TestSubscriber<Double>()
+        val comparableSubscriber = TestSubscriber<Comparable<*>>()
+
+        source.ofType<Int>().subscribe(intSubscriber)
+        source.ofType<BigDecimal>().subscribe(bigDecimalSubscriber)
+        source.ofType<Double>().subscribe(doubleSubscriber)
+        source.ofType<Comparable<*>>().subscribe(comparableSubscriber)
+
+        intSubscriber.apply {
+            assertValues(2, 15)
+            assertNoErrors()
+            assertCompleted()
+        }
+
+        bigDecimalSubscriber.apply {
+            assertValues(BigDecimal.valueOf(15, 1), BigDecimal.valueOf(42))
+            assertNoErrors()
+            assertCompleted()
+        }
+
+        doubleSubscriber.apply {
+            assertNoValues()
+            assertNoErrors()
+            assertCompleted()
+        }
+
+        comparableSubscriber.apply {
+            assertValues(BigDecimal.valueOf(15, 1), 2, BigDecimal.valueOf(42), 15)
+            assertNoErrors()
+            assertCompleted()
+        }
     }
 }


### PR DESCRIPTION
I thought it would be nice to have a kotlin wrapper for `ofType` like we have it for `cast`. 

So that 

``` kotlin
observable.ofType(BigDecimal::class.java)
```

becomes

``` kotlin
observable.ofType<BigDecimal>()
```
