### PR TITLE
Add emitterObservable(); nicer Observable.fromEmitter().

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,5 +1,5 @@
 buildscript {
-  ext.kotlin_version = '1.0.2'
+  ext.kotlin_version = '1.0.3'
   repositories { jcenter() }
   dependencies { classpath 'com.netflix.nebula:gradle-rxjava-project-plugin:2.+',
                            "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version" }
@@ -9,7 +9,7 @@ apply plugin: 'rxjava-project'
 apply plugin: 'kotlin'
 
 dependencies {
-    compile 'io.reactivex:rxjava:1.1.5'
+    compile 'io.reactivex:rxjava:1.1.10'
     compile "org.jetbrains.kotlin:kotlin-stdlib:$kotlin_version"
     testCompile 'org.funktionale:funktionale:0.8'
     testCompile 'junit:junit:4.12'

--- a/src/main/kotlin/rx/lang/kotlin/observables.kt
+++ b/src/main/kotlin/rx/lang/kotlin/observables.kt
@@ -1,5 +1,6 @@
 package rx.lang.kotlin
 
+import rx.AsyncEmitter
 import rx.Observable
 import rx.Subscriber
 import rx.Subscription
@@ -15,6 +16,15 @@ fun <T> deferredObservable(body : () -> Observable<T>) : Observable<T> = Observa
 private fun <T> Iterator<T>.toIterable() = object : Iterable<T> {
     override fun iterator(): Iterator<T> = this@toIterable
 }
+
+/**
+ * An alias to [Observable.fromEmitter] but with reversed parameters, allowing for more idiomatic usage in Kotlin.
+ * ```
+ * val myObservable = emitterObservable(BackpressureMode.NONE) { emitter -> }
+ * ```
+ */
+fun <T> emitterObservable(backpressure: AsyncEmitter.BackpressureMode, body: (emitter: AsyncEmitter<in T>) -> Unit): Observable<T> =
+        Observable.fromEmitter<T>(body, backpressure)
 
 fun BooleanArray.toObservable() : Observable<Boolean> = this.toList().toObservable()
 fun ByteArray.toObservable() : Observable<Byte> = this.toList().toObservable()

--- a/src/test/kotlin/rx/lang/kotlin/ObservablesTest.kt
+++ b/src/test/kotlin/rx/lang/kotlin/ObservablesTest.kt
@@ -2,6 +2,7 @@ package rx.lang.kotlin
 
 import org.junit.Assert.*
 import org.junit.Ignore
+import rx.AsyncEmitter
 import rx.Observable
 import rx.observers.TestSubscriber
 import java.util.concurrent.atomic.AtomicInteger
@@ -13,6 +14,9 @@ class ObservablesTest {
         val o0 : Observable<Int> = emptyObservable()
         observable<Int> { s -> s.onNext(1); s.onNext(777); s.onCompleted() }.toList().forEach {
             assertEquals(listOf(1, 777), it)
+        }
+        emitterObservable<Int>(AsyncEmitter.BackpressureMode.NONE) { e -> e.onNext(1); e.onNext(2); e.onCompleted() }.toList().forEach {
+            assertEquals(listOf(1, 2), it)
         }
         val o1 : Observable<Int> = listOf(1, 2, 3).toObservable()
         val o2 : Observable<List<Int>> = listOf(1, 2, 3).toSingletonObservable()


### PR DESCRIPTION
I'm proposing this change as an alternative to #78, as I feel it doesn't add much benefit in its current form.

`Observable.fromAsync()` is very handy way to make observables, but using it in Kotlin doesn't look great.

``` kotlin
val myObs = Observable.fromAsync<String>({ emitter ->
  // Emit some strings.
}, BackpressureMode.NONE)
```

`asyncToObservable()` is an alias with reversed `backpressure` and `emitter` parameters, allowing the emitter to be declared outside the calling params.

``` kotlin
val myObs = asyncToObservable<String>(BackpressureMode.NONE) { emitter->
  // Emit some strings.
}
```
