### PR TITLE
Add flatZipWith for zip functions that return an Observable

### DIFF
--- a/src/main/kotlin/rx/lang/kotlin/observables.kt
+++ b/src/main/kotlin/rx/lang/kotlin/observables.kt
@@ -101,7 +101,34 @@ fun <T, R> List<Observable<T>>.combineLatest(combineFunction: (args: List<T>) ->
  */
 @Suppress("UNCHECKED_CAST")
 fun <T, R> List<Observable<T>>.zip(zipFunction: (args: List<T>) -> R): Observable<R> =
-        Observable.zip(this, { zipFunction(it.asList() as List<T>) })
+        Observable.zip(this, { zipFunction(it.asList() as List<T>) })@Suppress("UNCHECKED_CAST")
+
+fun <T, R> List<Observable<T>>.flatZip(zipFunction: (args: List<T>) -> Observable<R>): Observable<R> =
+        Observable.zip(this, { zipFunction(it.asList() as List<T>) }).flatMap { it }
+
+fun <T, T1, R> Observable<T>.flatZipWith(o1: Observable<out T1>, zipFunction: (t: T, o1: T1) -> Observable<R>): Observable<R> =
+        Observable.zip(this, o1, zipFunction).flatMap { it }
+
+fun <T, T1, T2, R> Observable<T>.flatZipWith(o1: Observable<out T1>, o2: Observable<out T2>, zipFunction: (t: T, o1: T1, o2: T2) -> Observable<R>): Observable<R> =
+        Observable.zip(this, o1, o2, zipFunction).flatMap { it }
+
+fun <T, T1, T2, T3, R> Observable<T>.flatZipWith(o1: Observable<out T1>, o2: Observable<out T2>, o3: Observable<out T3>, zipFunction: (t: T, o1: T1, o2: T2, o3: T3) -> Observable<R>): Observable<R> =
+        Observable.zip(this, o1, o2, o3, zipFunction).flatMap { it }
+
+fun <T, T1, T2, T3, T4, R> Observable<T>.flatZipWith(o1: Observable<out T1>, o2: Observable<out T2>, o3: Observable<out T3>, o4: Observable<out T4>, zipFunction: (t: T, o1: T1, o2: T2, o3: T3, o4: T4) -> Observable<R>): Observable<R> =
+        Observable.zip(this, o1, o2, o3, o4, zipFunction).flatMap { it }
+
+fun <T, T1, T2, T3, T4, T5, R> Observable<T>.flatZipWith(o1: Observable<out T1>, o2: Observable<out T2>, o3: Observable<out T3>, o4: Observable<out T4>, o5: Observable<out T5>, zipFunction: (t: T, o1: T1, o2: T2, o3: T3, o4: T4, o5: T5) -> Observable<R>): Observable<R> =
+        Observable.zip(this, o1, o2, o3, o4, o5, zipFunction).flatMap { it }
+
+fun <T, T1, T2, T3, T4, T5, T6, R> Observable<T>.flatZipWith(o1: Observable<out T1>, o2: Observable<out T2>, o3: Observable<out T3>, o4: Observable<out T4>, o5: Observable<out T5>, o6: Observable<out T6>, zipFunction: (t: T, o1: T1, o2: T2, o3: T3, o4: T4, o5: T5, o6: T6) -> Observable<R>): Observable<R> =
+        Observable.zip(this, o1, o2, o3, o4, o5, o6, zipFunction).flatMap { it }
+
+fun <T, T1, T2, T3, T4, T5, T6, T7, R> Observable<T>.flatZipWith(o1: Observable<out T1>, o2: Observable<out T2>, o3: Observable<out T3>, o4: Observable<out T4>, o5: Observable<out T5>, o6: Observable<out T6>, o7: Observable<T7>, zipFunction: (t: T, o1: T1, o2: T2, o3: T3, o4: T4, o5: T5, o6: T6, o7: T7) -> Observable<R>): Observable<R> =
+        Observable.zip(this, o1, o2, o3, o4, o5, o6, o7, zipFunction).flatMap { it }
+
+fun <T, T1, T2, T3, T4, T5, T6, T7, T8, R> Observable<T>.flatZipWith(o1: Observable<out T1>, o2: Observable<out T2>, o3: Observable<out T3>, o4: Observable<out T4>, o5: Observable<out T5>, o6: Observable<out T6>, o7: Observable<T7>, o8: Observable<T8>, zipFunction: (t: T, o1: T1, o2: T2, o3: T3, o4: T4, o5: T5, o6: T6, o7: T7, o8: T8) -> Observable<R>): Observable<R> =
+        Observable.zip(this, o1, o2, o3, o4, o5, o6, o7, o8, zipFunction).flatMap { it }
 
 /**
  * Returns an Observable that emits the items emitted by the source Observable, converted to the specified type.

--- a/src/test/kotlin/rx/lang/kotlin/ObservablesTest.kt
+++ b/src/test/kotlin/rx/lang/kotlin/ObservablesTest.kt
@@ -152,6 +152,110 @@ class ObservablesTest {
         assertEquals(list, list.map { it.toSingletonObservable() }.zip { it }.toBlocking().first())
     }
 
+    @test fun testFlatZip() {
+        val list = listOf(1,2,3,2,3,4,3,4,5)
+        assertEquals(list, list.map { it.toSingletonObservable() }.flatZip { it.toSingletonObservable() }.toBlocking().first())
+    }
+
+    @test fun testFlatZipWith1() {
+        val list = 1.toSingletonObservable().flatZipWith(
+            2.toSingletonObservable(),
+            { a, b -> Observable.from(listOf(a, b))}).toList().toBlocking().first()
+
+        assertEquals(listOf(1, 2), list)
+    }
+
+    @test fun testFlatZipWith2() {
+        val list = 1.toSingletonObservable().flatZipWith(
+            2.toSingletonObservable(),
+            3.toSingletonObservable(),
+            { a, b, c -> Observable.from(listOf(a, b, c))})
+            .toList().toBlocking().first()
+
+        assertEquals(listOf(1, 2, 3), list)
+    }
+
+    @test fun testFlatZipWith3() {
+        val list = 1.toSingletonObservable().flatZipWith(
+            2.toSingletonObservable(),
+            3.toSingletonObservable(),
+            4.toSingletonObservable(),
+            { a, b, c, d -> Observable.from(listOf(a, b, c, d))})
+            .toList().toBlocking().first()
+
+        assertEquals(listOf(1, 2, 3, 4), list)
+    }
+
+    @test fun testFlatZipWith4() {
+        val list = 1.toSingletonObservable().flatZipWith(
+            2.toSingletonObservable(),
+            3.toSingletonObservable(),
+            4.toSingletonObservable(),
+            5.toSingletonObservable(),
+            { a, b, c, d, e -> Observable.from(listOf(a, b, c, d, e))})
+            .toList().toBlocking().first()
+
+        assertEquals(listOf(1, 2, 3, 4, 5), list)
+    }
+
+    @test fun testFlatZipWith5() {
+        val list = 1.toSingletonObservable().flatZipWith(
+            2.toSingletonObservable(),
+            3.toSingletonObservable(),
+            4.toSingletonObservable(),
+            5.toSingletonObservable(),
+            6.toSingletonObservable(),
+            { a, b, c, d, e, f -> Observable.from(listOf(a, b, c, d, e, f))})
+            .toList().toBlocking().first()
+
+        assertEquals(listOf(1, 2, 3, 4, 5, 6), list)
+    }
+
+    @test fun testFlatZipWith6() {
+        val list = 1.toSingletonObservable().flatZipWith(
+            2.toSingletonObservable(),
+            3.toSingletonObservable(),
+            4.toSingletonObservable(),
+            5.toSingletonObservable(),
+            6.toSingletonObservable(),
+            7.toSingletonObservable(),
+            { a, b, c, d, e, f, g -> Observable.from(listOf(a, b, c, d, e, f, g))})
+            .toList().toBlocking().first()
+
+        assertEquals(listOf(1, 2, 3, 4, 5, 6, 7), list)
+    }
+
+    @test fun testFlatZipWith7() {
+        val list = 1.toSingletonObservable().flatZipWith(
+            2.toSingletonObservable(),
+            3.toSingletonObservable(),
+            4.toSingletonObservable(),
+            5.toSingletonObservable(),
+            6.toSingletonObservable(),
+            7.toSingletonObservable(),
+            8.toSingletonObservable(),
+            { a, b, c, d, e, f, g, h -> Observable.from(listOf(a, b, c, d, e, f, g, h))})
+            .toList().toBlocking().first()
+
+        assertEquals(listOf(1, 2, 3, 4, 5, 6, 7, 8), list)
+    }
+
+    @test fun testFlatZipWith8() {
+        val list = 1.toSingletonObservable().flatZipWith(
+            2.toSingletonObservable(),
+            3.toSingletonObservable(),
+            4.toSingletonObservable(),
+            5.toSingletonObservable(),
+            6.toSingletonObservable(),
+            7.toSingletonObservable(),
+            8.toSingletonObservable(),
+            9.toSingletonObservable(),
+            { a, b, c, d, e, f, g, h, i -> Observable.from(listOf(a, b, c, d, e, f, g, h, i))})
+            .toList().toBlocking().first()
+
+        assertEquals(listOf(1, 2, 3, 4, 5, 6, 7, 8, 9), list)
+    }
+
     @test fun testCast() {
         val source = Observable.just<Any>(1, 2)
         val observable = source.cast<Int>()


### PR DESCRIPTION
I've run into few cases where I need to return a new observable from the zip function.  flatZip would be a nice addition instead of having to chain `flatMap { it }` after the normal zip function.
