### PR TITLE
Add onStart and onFinish fuctions to subscribeBy

### DIFF
--- a/src/main/kotlin/io/reactivex/rxkotlin/subscribers.kt
+++ b/src/main/kotlin/io/reactivex/rxkotlin/subscribers.kt
@@ -23,7 +23,7 @@ fun <T : Any> Observable<T>.subscribeBy(
         onFinish: (() -> Unit)? = null
 ): Disposable {
     onStart?.invoke()
-    val withOnFinish = if(onFinish != null) doFinally { onFinish() } else this
+    val withOnFinish = if (onFinish != null) doFinally { onFinish() } else this
     return withOnFinish.subscribe(onNext, onError, onComplete)
 }
 
@@ -38,7 +38,7 @@ fun <T : Any> Flowable<T>.subscribeBy(
         onFinish: (() -> Unit)? = null
 ): Disposable {
     onStart?.invoke()
-    val withOnFinish = if(onFinish != null) doFinally { onFinish() } else this
+    val withOnFinish = if (onFinish != null) doFinally { onFinish() } else this
     return withOnFinish.subscribe(onNext, onError, onComplete)
 }
 
@@ -52,7 +52,7 @@ fun <T : Any> Single<T>.subscribeBy(
         onFinish: (() -> Unit)? = null
 ): Disposable {
     onStart?.invoke()
-    val withOnFinish = if(onFinish != null) doFinally { onFinish() } else this
+    val withOnFinish = if (onFinish != null) doFinally { onFinish() } else this
     return withOnFinish.subscribe(onSuccess, onError)
 }
 
@@ -62,27 +62,15 @@ fun <T : Any> Single<T>.subscribeBy(
 fun <T : Any> Maybe<T>.subscribeBy(
         onSuccess: (T) -> Unit = onNextStub,
         onError: (Throwable) -> Unit = onErrorStub,
-        onComplete: () -> Unit = onCompleteStub,
-        onStart: (() -> Unit)? = null,
-        onFinish: (() -> Unit)? = null
-): Disposable {
-    onStart?.invoke()
-    val withOnFinish = if(onFinish != null) doFinally { onFinish() } else this
-    return withOnFinish.subscribe(onSuccess, onError, onComplete)
-}
+        onComplete: () -> Unit = onCompleteStub
+) = subscribe(onSuccess, onError, onComplete)
 
 /**
  * Overloaded subscribe function that allow passing named parameters
  */
 fun Completable.subscribeBy(
         onError: (Throwable) -> Unit = onErrorStub,
-        onComplete: () -> Unit = onCompleteStub,
-        onStart: (() -> Unit)? = null,
-        onFinish: (() -> Unit)? = null
-): Disposable {
-    onStart?.invoke()
-    val withOnFinish = if(onFinish != null) doFinally { onFinish() } else this
-    return withOnFinish.subscribe(onComplete, onError)
-}
+        onComplete: () -> Unit = onCompleteStub
+): Disposable = subscribe(onComplete, onError)
 
 class OnErrorNotImplementedException(e: Throwable) : RuntimeException(e)

--- a/src/main/kotlin/io/reactivex/rxkotlin/subscribers.kt
+++ b/src/main/kotlin/io/reactivex/rxkotlin/subscribers.kt
@@ -18,8 +18,14 @@ private val onCompleteStub: () -> Unit = {}
 fun <T : Any> Observable<T>.subscribeBy(
         onNext: (T) -> Unit = onNextStub,
         onError: (Throwable) -> Unit = onErrorStub,
-        onComplete: () -> Unit = onCompleteStub
-): Disposable = subscribe(onNext, onError, onComplete)
+        onComplete: () -> Unit = onCompleteStub,
+        onStart: (() -> Unit)? = null,
+        onFinish: (() -> Unit)? = null
+): Disposable {
+    onStart?.invoke()
+    val withOnFinish = if(onFinish != null) doFinally { onFinish() } else this
+    return withOnFinish.subscribe(onNext, onError, onComplete)
+}
 
 /**
  * Overloaded subscribe function that allow passing named parameters
@@ -27,16 +33,28 @@ fun <T : Any> Observable<T>.subscribeBy(
 fun <T : Any> Flowable<T>.subscribeBy(
         onNext: (T) -> Unit = onNextStub,
         onError: (Throwable) -> Unit = onErrorStub,
-        onComplete: () -> Unit = onCompleteStub
-): Disposable = subscribe(onNext, onError, onComplete)
+        onComplete: () -> Unit = onCompleteStub,
+        onStart: (() -> Unit)? = null,
+        onFinish: (() -> Unit)? = null
+): Disposable {
+    onStart?.invoke()
+    val withOnFinish = if(onFinish != null) doFinally { onFinish() } else this
+    return withOnFinish.subscribe(onNext, onError, onComplete)
+}
 
 /**
  * Overloaded subscribe function that allow passing named parameters
  */
 fun <T : Any> Single<T>.subscribeBy(
         onSuccess: (T) -> Unit = onNextStub,
-        onError: (Throwable) -> Unit = onErrorStub
-): Disposable = subscribe(onSuccess, onError)
+        onError: (Throwable) -> Unit = onErrorStub,
+        onStart: (() -> Unit)? = null,
+        onFinish: (() -> Unit)? = null
+): Disposable {
+    onStart?.invoke()
+    val withOnFinish = if(onFinish != null) doFinally { onFinish() } else this
+    return withOnFinish.subscribe(onSuccess, onError)
+}
 
 /**
  * Overloaded subscribe function that allow passing named parameters
@@ -44,15 +62,27 @@ fun <T : Any> Single<T>.subscribeBy(
 fun <T : Any> Maybe<T>.subscribeBy(
         onSuccess: (T) -> Unit = onNextStub,
         onError: (Throwable) -> Unit = onErrorStub,
-        onComplete: () -> Unit = onCompleteStub
-): Disposable = subscribe(onSuccess, onError, onComplete)
+        onComplete: () -> Unit = onCompleteStub,
+        onStart: (() -> Unit)? = null,
+        onFinish: (() -> Unit)? = null
+): Disposable {
+    onStart?.invoke()
+    val withOnFinish = if(onFinish != null) doFinally { onFinish() } else this
+    return withOnFinish.subscribe(onSuccess, onError, onComplete)
+}
 
 /**
  * Overloaded subscribe function that allow passing named parameters
  */
 fun Completable.subscribeBy(
         onError: (Throwable) -> Unit = onErrorStub,
-        onComplete: () -> Unit = onCompleteStub
-): Disposable = subscribe(onComplete, onError)
+        onComplete: () -> Unit = onCompleteStub,
+        onStart: (() -> Unit)? = null,
+        onFinish: (() -> Unit)? = null
+): Disposable {
+    onStart?.invoke()
+    val withOnFinish = if(onFinish != null) doFinally { onFinish() } else this
+    return withOnFinish.subscribe(onComplete, onError)
+}
 
 class OnErrorNotImplementedException(e: Throwable) : RuntimeException(e)

--- a/src/main/kotlin/io/reactivex/rxkotlin/subscribers.kt
+++ b/src/main/kotlin/io/reactivex/rxkotlin/subscribers.kt
@@ -63,7 +63,7 @@ fun <T : Any> Maybe<T>.subscribeBy(
         onSuccess: (T) -> Unit = onNextStub,
         onError: (Throwable) -> Unit = onErrorStub,
         onComplete: () -> Unit = onCompleteStub
-) = subscribe(onSuccess, onError, onComplete)
+): Disposable = subscribe(onSuccess, onError, onComplete)
 
 /**
  * Overloaded subscribe function that allow passing named parameters

--- a/src/test/kotlin/io/reactivex/rxkotlin/SubscribersFunctionsCallsOrderTests.kt
+++ b/src/test/kotlin/io/reactivex/rxkotlin/SubscribersFunctionsCallsOrderTests.kt
@@ -1,0 +1,167 @@
+package io.reactivex.rxkotlin
+
+import io.reactivex.*
+import io.reactivex.disposables.CompositeDisposable
+import org.junit.Assert
+import org.junit.Test
+import java.util.concurrent.CountDownLatch
+import java.util.concurrent.TimeUnit
+
+class SubscribersFunctionsCallsOrderTests {
+
+    private val onStartToken = "onStart"
+    private val onNextToken = "onNext"
+    private val onSuccessToken = "onSuccessToken"
+    private val onCompleteToken = "onComplete"
+    private val onFinishToken = "onFinish"
+    private val onErrorToken = "onError"
+
+    @Test fun testObservableSubscribeByOnStartOnFinishOrder() {
+        val singleEventDelayedObservable = Observable
+                .just("test")
+                .delay(100, TimeUnit.MILLISECONDS)
+        val tokens = getTokenOrderFor(singleEventDelayedObservable)
+        Assert.assertEquals(listOf(onStartToken, onNextToken, onCompleteToken, onFinishToken), tokens)
+    }
+
+    @Test fun testObservableSubscribeByOnStartOnFinishWithError() {
+        val singleErrorDelayedObservable = Observable
+                .error<String>(TestError())
+                .delay(100, TimeUnit.MILLISECONDS)
+        val tokens = getTokenOrderFor(singleErrorDelayedObservable)
+        Assert.assertEquals(listOf(onStartToken, onErrorToken, onFinishToken), tokens)
+    }
+
+    @Test fun testFlowableSubscribeByOnStartOnFinishOrder() {
+        val singleEventDelayedFlowable = Flowable
+                .just("test")
+                .delay(100, TimeUnit.MILLISECONDS)
+        val tokens = getTokenOrderFor(singleEventDelayedFlowable)
+        Assert.assertEquals(listOf(onStartToken, onNextToken, onCompleteToken, onFinishToken), tokens)
+    }
+
+    @Test fun testFlowableSubscribeByOnStartOnFinishWithError() {
+        val singleErrorDelayedFlowable = Observable
+                .error<String>(TestError())
+                .delay(100, TimeUnit.MILLISECONDS)
+        val tokens = getTokenOrderFor(singleErrorDelayedFlowable)
+        Assert.assertEquals(listOf(onStartToken, onErrorToken, onFinishToken), tokens)
+    }
+
+    @Test fun testSingleSubscribeByOnStartOnFinishOrder() {
+        val singleEventDelayedFlowable = Single
+                .just("test")
+                .delay(100, TimeUnit.MILLISECONDS)
+        val tokens = getTokenOrderFor(singleEventDelayedFlowable)
+        Assert.assertEquals(listOf(onStartToken, onSuccessToken, onFinishToken), tokens)
+    }
+
+    @Test fun testSingleSubscribeByOnStartOnFinishWithError() {
+        val singleErrorDelayedFlowable = Single
+                .error<String>(TestError())
+                .delay(100, TimeUnit.MILLISECONDS)
+        val tokens = getTokenOrderFor(singleErrorDelayedFlowable)
+        Assert.assertEquals(listOf(onStartToken, onErrorToken, onFinishToken), tokens)
+    }
+
+    @Test fun testMaybeSubscribeByOnStartOnFinishOrder() {
+val singleEventDelayedFlowable = Maybe
+        .just("test")
+        .delay(100, TimeUnit.MILLISECONDS)
+val tokens = getTokenOrderFor(singleEventDelayedFlowable)
+        Assert.assertEquals(listOf(onSuccessToken), tokens)
+    }
+
+    @Test fun testMaybeSubscribeByOnStartOnFinishWithError() {
+        val singleErrorDelayedFlowable = Maybe
+                .error<String>(TestError())
+                .delay(100, TimeUnit.MILLISECONDS)
+        val tokens = getTokenOrderFor(singleErrorDelayedFlowable)
+        Assert.assertEquals(listOf(onErrorToken), tokens)
+    }
+
+    @Test fun testCompletableSubscribeByOnStartOnFinishOrder() {
+        val singleEventDelayedObservable = Observable.just("test").delay(100, TimeUnit.MILLISECONDS)
+        val singleDelayedCompletable = Completable.fromObservable(singleEventDelayedObservable)
+        val tokens = getTokenOrderFor(singleDelayedCompletable)
+        Assert.assertEquals(listOf(onCompleteToken), tokens)
+    }
+
+    @Test fun testCompletableSubscribeByOnStartOnFinishWithError() {
+        val singleErrorDelayedObservable = Observable.error<String>(TestError()).delay(100, TimeUnit.MILLISECONDS)
+        val singleErrorDelayedCompletable = Completable.fromObservable(singleErrorDelayedObservable)
+        val tokens = getTokenOrderFor(singleErrorDelayedCompletable)
+        Assert.assertEquals(listOf(onErrorToken), tokens)
+    }
+
+    private fun <T : Any> getTokenOrderFor(observable: Observable<T>): List<String> {
+        val latch = CountDownLatch(1)
+        var tokens = listOf<String>()
+        val subscription = observable.subscribeBy(
+                onStart = { tokens += onStartToken },
+                onNext = { tokens += onNextToken },
+                onComplete = { tokens += onCompleteToken },
+                onError = { tokens += onErrorToken },
+                onFinish = { tokens += onFinishToken; latch.countDown() }
+        )
+        latch.await(5, TimeUnit.SECONDS)
+        subscription.dispose()
+        return tokens
+    }
+
+    private fun <T : Any> getTokenOrderFor(flowable: Flowable<T>): List<String> {
+        val latch = CountDownLatch(1)
+        var tokens = listOf<String>()
+        val subscription = flowable.subscribeBy(
+                onStart = { tokens += onStartToken },
+                onNext = { tokens += onNextToken },
+                onComplete = { tokens += onCompleteToken },
+                onError = { tokens += onErrorToken },
+                onFinish = { tokens += onFinishToken; latch.countDown() }
+        )
+        latch.await(5, TimeUnit.SECONDS)
+        subscription.dispose()
+        return tokens
+    }
+
+    private fun <T : Any> getTokenOrderFor(single: Single<T>): List<String> {
+        val latch = CountDownLatch(1)
+        var tokens = listOf<String>()
+        val subscription = single.subscribeBy(
+                onStart = { tokens += onStartToken },
+                onSuccess = { tokens += onSuccessToken },
+                onError = { tokens += onErrorToken },
+                onFinish = { tokens += onFinishToken; latch.countDown() }
+        )
+        latch.await(5, TimeUnit.SECONDS)
+        subscription.dispose()
+        return tokens
+    }
+
+    private fun <T : Any> getTokenOrderFor(maybe: Maybe<T>): List<String> {
+        val latch = CountDownLatch(1)
+        var tokens = listOf<String>()
+        val subscription = maybe.subscribeBy(
+                onSuccess = { tokens += onSuccessToken },
+                onComplete = { tokens += onCompleteToken; latch.countDown() },
+                onError = { tokens += onErrorToken; latch.countDown() }
+        )
+        latch.await(5, TimeUnit.SECONDS)
+        subscription.dispose()
+        return tokens
+    }
+
+    private fun getTokenOrderFor(completable: Completable): List<String> {
+        val latch = CountDownLatch(1)
+        var tokens = listOf<String>()
+        val subscription = completable.subscribeBy(
+                onComplete = { tokens += onCompleteToken; latch.countDown() },
+                onError = { tokens += onErrorToken; latch.countDown() }
+        )
+        latch.await(5, TimeUnit.SECONDS)
+        subscription.dispose()
+        return tokens
+    }
+
+    class TestError : Throwable()
+}

--- a/src/test/kotlin/io/reactivex/rxkotlin/SubscriptionTest.kt
+++ b/src/test/kotlin/io/reactivex/rxkotlin/SubscriptionTest.kt
@@ -5,7 +5,7 @@ import io.reactivex.disposables.CompositeDisposable
 import org.junit.Test
 import java.util.concurrent.TimeUnit
 
-class SubscriptionTests {
+class SubscriptionTest {
 
     @Test fun testSubscriptionAddTo() {
         val compositeSubscription = CompositeDisposable()

--- a/src/test/kotlin/io/reactivex/rxkotlin/SubscriptionTests.kt
+++ b/src/test/kotlin/io/reactivex/rxkotlin/SubscriptionTests.kt
@@ -5,7 +5,8 @@ import io.reactivex.disposables.CompositeDisposable
 import org.junit.Test
 import java.util.concurrent.TimeUnit
 
-class SubscriptionTest {
+class SubscriptionTests {
+
     @Test fun testSubscriptionAddTo() {
         val compositeSubscription = CompositeDisposable()
 


### PR DESCRIPTION
This it really useful. Example:
```
subscriptions += deleteEventApi.call(booking.id)
        .applySchedulers()
        .subscribeBy (
                onStart = { view.progressBarVisibility = true },
                onSuccess = { onBookingCancelled() },
                onFinish = { view.progressBarVisibility = false }
        )
```
or
```
subscriptions += addEventApi.call(booking)
        .applySchedulers()
        .subscribeBy (
                onStart = { view.showProgressBar() },
                onSuccess = { showEventData(it) },
                onFinish = { view.hideProgressBar() }
        )
```