### PR TITLE
Create extension functions that start addressing #103

### DIFF
--- a/src/main/kotlin/io/reactivex/rxkotlin/flowable.kt
+++ b/src/main/kotlin/io/reactivex/rxkotlin/flowable.kt
@@ -1,6 +1,11 @@
 package io.reactivex.rxkotlin
 
 import io.reactivex.Flowable
+import io.reactivex.functions.BiFunction
+import io.reactivex.functions.Function3
+import io.reactivex.functions.Function4
+import io.reactivex.functions.Function5
+import org.reactivestreams.Publisher
 
 
 fun BooleanArray.toFlowable(): Flowable<Boolean> = asIterable().toFlowable()
@@ -62,6 +67,37 @@ inline fun <reified R : Any> Flowable<*>.ofType(): Flowable<R> = ofType(R::class
 private fun <T : Any> Iterator<T>.toIterable() = object : Iterable<T> {
     override fun iterator(): Iterator<T> = this@toIterable
 }
+
+/**
+ * An alias to [Flowable.withLatestFrom], but allowing for cleaner lambda syntax.
+ */
+inline fun <T, U, R> Flowable<T>.withLatestFrom(other: Publisher<U>, crossinline combiner: (T, U) -> R): Flowable<R>
+        = withLatestFrom(other, BiFunction<T, U, R> { t, u -> combiner.invoke(t, u)  })
+
+/**
+ * An alias to [Flowable.withLatestFrom], but allowing for cleaner lambda syntax.
+ */
+inline fun <T, T1, T2, R> Flowable<T>.withLatestFrom(o1: Publisher<T1>, o2: Publisher<T2>, crossinline combiner: (T, T1, T2) -> R): Flowable<R>
+        = withLatestFrom(o1, o2, Function3<T, T1, T2, R> { t, t1, t2 -> combiner.invoke(t, t1, t2) })
+
+/**
+ * An alias to [Flowable.withLatestFrom], but allowing for cleaner lambda syntax.
+ */
+inline fun <T, T1, T2, T3, R> Flowable<T>.withLatestFrom(o1: Publisher<T1>, o2: Publisher<T2>, o3: Publisher<T3>, crossinline combiner: (T, T1, T2, T3) -> R): Flowable<R>
+        = withLatestFrom(o1, o2, o3, Function4<T, T1, T2, T3, R> { t, t1, t2, t3 -> combiner.invoke(t, t1, t2, t3) })
+
+/**
+ * An alias to [Flowable.withLatestFrom], but allowing for cleaner lambda syntax.
+ */
+inline fun <T, T1, T2, T3, T4, R> Flowable<T>.withLatestFrom(o1: Publisher<T1>, o2: Publisher<T2>, o3: Publisher<T3>, o4: Publisher<T4>, crossinline combiner: (T, T1, T2, T3, T4) -> R): Flowable<R>
+        = withLatestFrom(o1, o2, o3, o4, Function5<T, T1, T2, T3, T4, R> { t, t1, t2, t3, t4 -> combiner.invoke(t, t1, t2, t3, t4) })
+
+/**
+ * An alias to [Flowable.zipWith], but allowing for cleaner lambda syntax.
+ */
+inline fun <T, U, R> Flowable<T>.zipWith(other: Publisher<U>, crossinline zipper: (T, U) -> R): Flowable<R>
+        = zipWith(other, BiFunction { t, u -> zipper.invoke(t, u) })
+
 
 //EXTENSION FUNCTION OPERATORS
 

--- a/src/main/kotlin/io/reactivex/rxkotlin/maybe.kt
+++ b/src/main/kotlin/io/reactivex/rxkotlin/maybe.kt
@@ -2,7 +2,9 @@ package io.reactivex.rxkotlin
 
 import io.reactivex.Flowable
 import io.reactivex.Maybe
+import io.reactivex.MaybeSource
 import io.reactivex.Observable
+import io.reactivex.functions.BiFunction
 import java.util.concurrent.Callable
 import java.util.concurrent.Future
 
@@ -14,7 +16,11 @@ fun <T : Any> (() -> T).toMaybe(): Maybe<T> = Maybe.fromCallable(this)
 inline fun <reified R : Any> Maybe<Any>.cast(): Maybe<R> = cast(R::class.java)
 inline fun <reified R : Any> Maybe<Any>.ofType(): Maybe<R> = ofType(R::class.java)
 
-
+/**
+ * An alias to [Maybe.zipWith], but allowing for cleaner lambda syntax.
+ */
+inline fun <T, U, R> Maybe<T>.zipWith(other: MaybeSource<U>, crossinline zipper: (T, U) -> R): Maybe<R>
+        = zipWith(other, BiFunction { t, u -> zipper.invoke(t, u) })
 
 // EXTENSION FUNCTION OPERATORS
 

--- a/src/main/kotlin/io/reactivex/rxkotlin/observable.kt
+++ b/src/main/kotlin/io/reactivex/rxkotlin/observable.kt
@@ -1,6 +1,11 @@
 package io.reactivex.rxkotlin
 
 import io.reactivex.Observable
+import io.reactivex.ObservableSource
+import io.reactivex.functions.BiFunction
+import io.reactivex.functions.Function3
+import io.reactivex.functions.Function4
+import io.reactivex.functions.Function5
 
 
 fun BooleanArray.toObservable(): Observable<Boolean> = asIterable().toObservable()
@@ -62,6 +67,36 @@ inline fun <reified R : Any> Observable<*>.ofType(): Observable<R> = ofType(R::c
 private fun <T : Any> Iterator<T>.toIterable() = object : Iterable<T> {
     override fun iterator(): Iterator<T> = this@toIterable
 }
+
+/**
+ * An alias to [Observable.withLatestFrom], but allowing for cleaner lambda syntax.
+ */
+inline fun <T, U, R> Observable<T>.withLatestFrom(other: ObservableSource<U>, crossinline combiner: (T, U) -> R): Observable<R>
+        = withLatestFrom(other, BiFunction<T, U, R> { t, u -> combiner.invoke(t, u)  })
+
+/**
+ * An alias to [Observable.withLatestFrom], but allowing for cleaner lambda syntax.
+ */
+inline fun <T, T1, T2, R> Observable<T>.withLatestFrom(o1: ObservableSource<T1>, o2: ObservableSource<T2>, crossinline combiner: (T, T1, T2) -> R): Observable<R>
+        = withLatestFrom(o1, o2, Function3<T, T1, T2, R> { t, t1, t2 -> combiner.invoke(t, t1, t2) })
+
+/**
+ * An alias to [Observable.withLatestFrom], but allowing for cleaner lambda syntax.
+ */
+inline fun <T, T1, T2, T3, R> Observable<T>.withLatestFrom(o1: ObservableSource<T1>, o2: ObservableSource<T2>, o3: ObservableSource<T3>, crossinline combiner: (T, T1, T2, T3) -> R): Observable<R>
+        = withLatestFrom(o1, o2, o3, Function4<T, T1, T2, T3, R> { t, t1, t2, t3 -> combiner.invoke(t, t1, t2, t3) })
+
+/**
+ * An alias to [Observable.withLatestFrom], but allowing for cleaner lambda syntax.
+ */
+inline fun <T, T1, T2, T3, T4, R> Observable<T>.withLatestFrom(o1: ObservableSource<T1>, o2: ObservableSource<T2>, o3: ObservableSource<T3>, o4: ObservableSource<T4>, crossinline combiner: (T, T1, T2, T3, T4) -> R): Observable<R>
+        = withLatestFrom(o1, o2, o3, o4, Function5<T, T1, T2, T3, T4, R> { t, t1, t2, t3, t4 -> combiner.invoke(t, t1, t2, t3, t4) })
+
+/**
+ * An alias to [Observable.zipWith], but allowing for cleaner lambda syntax.
+ */
+inline fun <T, U, R> Observable<T>.zipWith(other: ObservableSource<U>, crossinline zipper: (T, U) -> R): Observable<R>
+        = zipWith(other, BiFunction { t, u -> zipper.invoke(t, u) })
 
 
 // EXTENSION FUNCTION OPERATORS

--- a/src/main/kotlin/io/reactivex/rxkotlin/single.kt
+++ b/src/main/kotlin/io/reactivex/rxkotlin/single.kt
@@ -3,6 +3,8 @@ package io.reactivex.rxkotlin
 import io.reactivex.Flowable
 import io.reactivex.Observable
 import io.reactivex.Single
+import io.reactivex.SingleSource
+import io.reactivex.functions.BiFunction
 import java.util.concurrent.Callable
 import java.util.concurrent.Future
 
@@ -13,6 +15,11 @@ fun <T : Any> (() -> T).toSingle(): Single<T> = Single.fromCallable(this)
 
 inline fun <reified R : Any> Single<Any>.cast(): Single<R> = cast(R::class.java)
 
+/**
+ * An alias to [Single.zipWith], but allowing for cleaner lambda syntax.
+ */
+inline fun <T, U, R> Single<T>.zipWith(other: SingleSource<U>, crossinline zipper: (T, U) -> R): Single<R>
+        = zipWith(other, BiFunction { t, u -> zipper.invoke(t, u) })
 
 // EXTENSION FUNCTION OPERATORS
 

--- a/src/test/kotlin/io/reactivex/rxkotlin/FlowableTest.kt
+++ b/src/test/kotlin/io/reactivex/rxkotlin/FlowableTest.kt
@@ -129,4 +129,16 @@ class FlowableTest {
         flowable.test()
                 .assertError(ClassCastException::class.java)
     }
+
+    @Test fun testWithLatestFrom() {
+        val emit1 = Flowable.just(1)
+        emit1.withLatestFrom(emit1) { a, b -> a + b }.test().assertValue(2)
+        emit1.withLatestFrom(emit1, emit1) { a, b, c -> a + b + c }.test().assertValue(3)
+        emit1.withLatestFrom(emit1, emit1, emit1) { a, b, c, d -> a + b + c + d }.test().assertValue(4)
+        emit1.withLatestFrom(emit1, emit1, emit1, emit1) { a, b, c, d, e -> a + b + c + d + e }.test().assertValue(5)
+    }
+
+    @Test fun testZipWith() {
+        Flowable.fromArray(1, 2).zipWith(Flowable.fromArray(3, 4)) { a, b -> a + b }.test().assertValues(4, 6)
+    }
 }

--- a/src/test/kotlin/io/reactivex/rxkotlin/ObservableTest.kt
+++ b/src/test/kotlin/io/reactivex/rxkotlin/ObservableTest.kt
@@ -1,7 +1,6 @@
 package io.reactivex.rxkotlin
 
 import io.reactivex.Observable
-import io.reactivex.observers.TestObserver
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertNotNull
 import org.junit.Ignore
@@ -175,4 +174,15 @@ class ObservableTest {
 
     }
 
+    @Test fun testWithLatestFrom() {
+        val emit1 = Observable.just(1)
+        emit1.withLatestFrom(emit1) { a, b -> a + b }.test().assertValue(2)
+        emit1.withLatestFrom(emit1, emit1) { a, b, c -> a + b + c }.test().assertValue(3)
+        emit1.withLatestFrom(emit1, emit1, emit1) { a, b, c, d -> a + b + c + d }.test().assertValue(4)
+        emit1.withLatestFrom(emit1, emit1, emit1, emit1) { a, b, c, d, e -> a + b + c + d + e }.test().assertValue(5)
+    }
+
+    @Test fun testZipWith() {
+        Observable.fromArray(1, 2).zipWith(Observable.fromArray(3, 4)) { a, b -> a + b }.test().assertValues(4, 6)
+    }
 }

--- a/src/test/kotlin/io/reactivex/rxkotlin/SingleTest.kt
+++ b/src/test/kotlin/io/reactivex/rxkotlin/SingleTest.kt
@@ -47,4 +47,8 @@ class SingleTest : KotlinTests() {
         Mockito.verify(a, Mockito.times(1))
                 .received("Hello World!")
     }
+
+    @Test fun testZipWith() {
+        Single.just(1).zipWith(Single.just(2)) { a, b -> a + b }.test().assertValue(3)
+    }
 }


### PR DESCRIPTION
Making this as a first step to addressing #103.

I've only created extension functions for now, as calls like `Observable.zip()` are going to be hard to overload neatly (since Kotlin doesn't support static extension functions).