### PR TITLE
Add BlockingObservable.subscribeBy

### DIFF
--- a/src/main/kotlin/rx/lang/kotlin/subscribers.kt
+++ b/src/main/kotlin/rx/lang/kotlin/subscribers.kt
@@ -5,6 +5,7 @@ import rx.Observable
 import rx.Single
 import rx.Subscription
 import rx.exceptions.OnErrorNotImplementedException
+import rx.observables.BlockingObservable
 
 private val onNextStub: (Any) -> Unit = {}
 private val onErrorStub: (Throwable) -> Unit = { throw OnErrorNotImplementedException(it) }
@@ -18,6 +19,15 @@ fun <T : Any> Observable<T>.subscribeBy(
         onError: (Throwable) -> Unit = onErrorStub,
         onCompleted: () -> Unit = onCompleteStub
 ): Subscription = subscribe(onNext, onError, onCompleted)
+
+/**
+ * Overloaded subscribe function that allow passing named parameters
+ */
+fun <T : Any> BlockingObservable<T>.subscribeBy(
+        onNext: (T) -> Unit = onNextStub,
+        onError: (Throwable) -> Unit = onErrorStub,
+        onCompleted: () -> Unit = onCompleteStub
+) = subscribe(onNext, onError, onCompleted)
 
 /**
  * Overloaded subscribe function that allow passing named parameters


### PR DESCRIPTION
It's currently surprising that this works: `Observable.just(1).subscribeBy(onNext={})`, but this doesn't:  `Observable.just(1).toBlocking().subscribeBy(onNext={})`

`BlockingObservable` is not a frequently used API, so I don't think it needs many extension functions like the other observable types, but this is a simple addition and keeps symmetry.

RxJava2 doesn't have `BlockingObservable`s, so there's no need to add anything to the 2.x branch.