### PR TITLE
Add blockingSubscribeBy

### DIFF
--- a/src/main/kotlin/io/reactivex/rxkotlin/subscribers.kt
+++ b/src/main/kotlin/io/reactivex/rxkotlin/subscribers.kt
@@ -1,10 +1,6 @@
 package io.reactivex.rxkotlin
 
-import io.reactivex.Completable
-import io.reactivex.Flowable
-import io.reactivex.Maybe
-import io.reactivex.Observable
-import io.reactivex.Single
+import io.reactivex.*
 import io.reactivex.disposables.Disposable
 import java.lang.RuntimeException
 
@@ -54,5 +50,23 @@ fun Completable.subscribeBy(
         onError: (Throwable) -> Unit = onErrorStub,
         onComplete: () -> Unit = onCompleteStub
 ): Disposable = subscribe(onComplete, onError)
+
+/**
+ * Overloaded blockingSubscribe function that allow passing named parameters
+ */
+fun <T : Any> Observable<T>.blockingSubscribeBy(
+        onNext: (T) -> Unit = onNextStub,
+        onError: (Throwable) -> Unit = onErrorStub,
+        onComplete: () -> Unit = onCompleteStub
+) = blockingSubscribe(onNext, onError, onComplete)
+
+/**
+ * Overloaded blockingSubscribe function that allow passing named parameters
+ */
+fun <T : Any> Flowable<T>.blockingSubscribeBy(
+        onNext: (T) -> Unit = onNextStub,
+        onError: (Throwable) -> Unit = onErrorStub,
+        onComplete: () -> Unit = onCompleteStub
+) = blockingSubscribe(onNext, onError, onComplete)
 
 class OnErrorNotImplementedException(e: Throwable) : RuntimeException(e)


### PR DESCRIPTION
Add `blockingSubscribeBy` extension functions to `Flowable` and `Observable` that wrap `blockingSubscribe`.

This is a companion to #118 for the 2.x branch.

I noticed two extra things in this file while I was here:

* There's a grammatical error the docstrings ("function that allow" should be "function that allows")
* You define your own `OnErrorNotImplementedException` instead of using the one defined in rxjava. Does anyone know why that is? I would be surprised if I tried to catch the standard error, only to have this custom one get raised.

I didn't make any extra changes to keep this PR simple, but I can add commits if you want me to.