### PR TITLE
Fix grammar in subscribeBy docstrings.

### DIFF
--- a/src/main/kotlin/io/reactivex/rxkotlin/subscribers.kt
+++ b/src/main/kotlin/io/reactivex/rxkotlin/subscribers.kt
@@ -9,7 +9,7 @@ private val onErrorStub: (Throwable) -> Unit = { throw OnErrorNotImplementedExce
 private val onCompleteStub: () -> Unit = {}
 
 /**
- * Overloaded subscribe function that allow passing named parameters
+ * Overloaded subscribe function that allows passing named parameters
  */
 fun <T : Any> Observable<T>.subscribeBy(
         onNext: (T) -> Unit = onNextStub,
@@ -18,7 +18,7 @@ fun <T : Any> Observable<T>.subscribeBy(
 ): Disposable = subscribe(onNext, onError, onComplete)
 
 /**
- * Overloaded subscribe function that allow passing named parameters
+ * Overloaded subscribe function that allows passing named parameters
  */
 fun <T : Any> Flowable<T>.subscribeBy(
         onNext: (T) -> Unit = onNextStub,
@@ -27,7 +27,7 @@ fun <T : Any> Flowable<T>.subscribeBy(
 ): Disposable = subscribe(onNext, onError, onComplete)
 
 /**
- * Overloaded subscribe function that allow passing named parameters
+ * Overloaded subscribe function that allows passing named parameters
  */
 fun <T : Any> Single<T>.subscribeBy(
         onSuccess: (T) -> Unit = onNextStub,
@@ -35,7 +35,7 @@ fun <T : Any> Single<T>.subscribeBy(
 ): Disposable = subscribe(onSuccess, onError)
 
 /**
- * Overloaded subscribe function that allow passing named parameters
+ * Overloaded subscribe function that allows passing named parameters
  */
 fun <T : Any> Maybe<T>.subscribeBy(
         onSuccess: (T) -> Unit = onNextStub,
@@ -44,7 +44,7 @@ fun <T : Any> Maybe<T>.subscribeBy(
 ): Disposable = subscribe(onSuccess, onError, onComplete)
 
 /**
- * Overloaded subscribe function that allow passing named parameters
+ * Overloaded subscribe function that allows passing named parameters
  */
 fun Completable.subscribeBy(
         onError: (Throwable) -> Unit = onErrorStub,
@@ -52,7 +52,7 @@ fun Completable.subscribeBy(
 ): Disposable = subscribe(onComplete, onError)
 
 /**
- * Overloaded blockingSubscribe function that allow passing named parameters
+ * Overloaded blockingSubscribe function that allows passing named parameters
  */
 fun <T : Any> Observable<T>.blockingSubscribeBy(
         onNext: (T) -> Unit = onNextStub,
@@ -61,7 +61,7 @@ fun <T : Any> Observable<T>.blockingSubscribeBy(
 ) = blockingSubscribe(onNext, onError, onComplete)
 
 /**
- * Overloaded blockingSubscribe function that allow passing named parameters
+ * Overloaded blockingSubscribe function that allows passing named parameters
  */
 fun <T : Any> Flowable<T>.blockingSubscribeBy(
         onNext: (T) -> Unit = onNextStub,


### PR DESCRIPTION
This fixes the minor grammar error in `subscribeBy` docstrings mentioned in #119. This affects the 2.x branch.