### PR TITLE
Move onNext, onSuccess operators in subscribeBy()

### DIFF
--- a/src/main/kotlin/io/reactivex/rxkotlin/subscribers.kt
+++ b/src/main/kotlin/io/reactivex/rxkotlin/subscribers.kt
@@ -12,36 +12,36 @@ private val onCompleteStub: () -> Unit = {}
  * Overloaded subscribe function that allows passing named parameters
  */
 fun <T : Any> Observable<T>.subscribeBy(
-        onNext: (T) -> Unit = onNextStub,
         onError: (Throwable) -> Unit = onErrorStub,
-        onComplete: () -> Unit = onCompleteStub
-): Disposable = subscribe(onNext, onError, onComplete)
+        onComplete: () -> Unit = onCompleteStub,
+        onNext: (T) -> Unit = onNextStub
+        ): Disposable = subscribe(onNext, onError, onComplete)
 
 /**
  * Overloaded subscribe function that allows passing named parameters
  */
 fun <T : Any> Flowable<T>.subscribeBy(
-        onNext: (T) -> Unit = onNextStub,
         onError: (Throwable) -> Unit = onErrorStub,
-        onComplete: () -> Unit = onCompleteStub
-): Disposable = subscribe(onNext, onError, onComplete)
+        onComplete: () -> Unit = onCompleteStub,
+        onNext: (T) -> Unit = onNextStub
+        ): Disposable = subscribe(onNext, onError, onComplete)
 
 /**
  * Overloaded subscribe function that allows passing named parameters
  */
 fun <T : Any> Single<T>.subscribeBy(
-        onSuccess: (T) -> Unit = onNextStub,
-        onError: (Throwable) -> Unit = onErrorStub
-): Disposable = subscribe(onSuccess, onError)
+        onError: (Throwable) -> Unit = onErrorStub,
+        onSuccess: (T) -> Unit = onNextStub
+        ): Disposable = subscribe(onSuccess, onError)
 
 /**
  * Overloaded subscribe function that allows passing named parameters
  */
 fun <T : Any> Maybe<T>.subscribeBy(
-        onSuccess: (T) -> Unit = onNextStub,
         onError: (Throwable) -> Unit = onErrorStub,
-        onComplete: () -> Unit = onCompleteStub
-): Disposable = subscribe(onSuccess, onError, onComplete)
+        onComplete: () -> Unit = onCompleteStub,
+        onSuccess: (T) -> Unit = onNextStub
+        ): Disposable = subscribe(onSuccess, onError, onComplete)
 
 /**
  * Overloaded subscribe function that allows passing named parameters
@@ -55,18 +55,18 @@ fun Completable.subscribeBy(
  * Overloaded blockingSubscribe function that allows passing named parameters
  */
 fun <T : Any> Observable<T>.blockingSubscribeBy(
-        onNext: (T) -> Unit = onNextStub,
         onError: (Throwable) -> Unit = onErrorStub,
-        onComplete: () -> Unit = onCompleteStub
-) = blockingSubscribe(onNext, onError, onComplete)
+        onComplete: () -> Unit = onCompleteStub,
+        onNext: (T) -> Unit = onNextStub
+        ) = blockingSubscribe(onNext, onError, onComplete)
 
 /**
  * Overloaded blockingSubscribe function that allows passing named parameters
  */
 fun <T : Any> Flowable<T>.blockingSubscribeBy(
-        onNext: (T) -> Unit = onNextStub,
         onError: (Throwable) -> Unit = onErrorStub,
-        onComplete: () -> Unit = onCompleteStub
-) = blockingSubscribe(onNext, onError, onComplete)
+        onComplete: () -> Unit = onCompleteStub,
+        onNext: (T) -> Unit = onNextStub
+        ) = blockingSubscribe(onNext, onError, onComplete)
 
 class OnErrorNotImplementedException(e: Throwable) : RuntimeException(e)

--- a/src/test/kotlin/io/reactivex/rxkotlin/FlowableTest.kt
+++ b/src/test/kotlin/io/reactivex/rxkotlin/FlowableTest.kt
@@ -1,14 +1,15 @@
 package io.reactivex.rxkotlin
 
-import io.reactivex.BackpressureStrategy
-import io.reactivex.Flowable
+import io.reactivex.*
 import io.reactivex.Flowable.create
-import io.reactivex.FlowableEmitter
+import org.junit.Assert
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertNotNull
 import org.junit.Ignore
 import org.junit.Test
+import org.mockito.Mockito
 import java.util.concurrent.atomic.AtomicInteger
+import java.util.concurrent.atomic.AtomicReference
 
 class FlowableTest {
 
@@ -148,5 +149,26 @@ class FlowableTest {
                 .map { (x, y, z) -> x * y * z }
                 .test()
                 .assertValues(600)
+    }
+    @Test
+    fun testSubscribeBy() {
+        val first = AtomicReference<String>()
+
+        Flowable.just("Alpha")
+                .subscribeBy {
+                    first.set(it)
+                }
+        Assert.assertTrue(first.get() == "Alpha")
+    }
+
+    @Test
+    fun testBlockingSubscribeBy() {
+        val first = AtomicReference<String>()
+
+        Flowable.just("Alpha")
+                .blockingSubscribeBy {
+                    first.set(it)
+                }
+        Assert.assertTrue(first.get() == "Alpha")
     }
 }

--- a/src/test/kotlin/io/reactivex/rxkotlin/MaybeTest.kt
+++ b/src/test/kotlin/io/reactivex/rxkotlin/MaybeTest.kt
@@ -1,0 +1,19 @@
+package io.reactivex.rxkotlin
+
+import io.reactivex.Maybe
+import org.junit.Assert
+import org.junit.Test
+import java.util.concurrent.atomic.AtomicReference
+
+class MaybeTest {
+    @Test
+    fun testSubscribeBy() {
+        val first = AtomicReference<String>()
+
+        Maybe.just("Alpha")
+                .subscribeBy {
+                    first.set(it)
+                }
+        Assert.assertTrue(first.get() == "Alpha")
+    }
+}

--- a/src/test/kotlin/io/reactivex/rxkotlin/ObservableTest.kt
+++ b/src/test/kotlin/io/reactivex/rxkotlin/ObservableTest.kt
@@ -1,12 +1,14 @@
 package io.reactivex.rxkotlin
 
 import io.reactivex.Observable
-import org.junit.Assert.assertEquals
-import org.junit.Assert.assertNotNull
+import io.reactivex.Single
+import org.junit.Assert.*
 import org.junit.Ignore
 import org.junit.Test
+import org.mockito.Mockito
 import java.math.BigDecimal
 import java.util.concurrent.atomic.AtomicInteger
+import java.util.concurrent.atomic.AtomicReference
 
 class ObservableTest {
 
@@ -189,4 +191,25 @@ class ObservableTest {
                 .assertValues(600)
     }
 
+    @Test
+    fun testSubscribeBy() {
+        val first = AtomicReference<String>()
+
+        Observable.just("Alpha")
+                .subscribeBy {
+                    first.set(it)
+                }
+        assertTrue(first.get() == "Alpha")
+    }
+
+    @Test
+    fun testBlockingSubscribeBy() {
+        val first = AtomicReference<String>()
+
+        Observable.just("Alpha")
+                .blockingSubscribeBy {
+                    first.set(it)
+                }
+        assertTrue(first.get() == "Alpha")
+    }
 }

--- a/src/test/kotlin/io/reactivex/rxkotlin/SingleTest.kt
+++ b/src/test/kotlin/io/reactivex/rxkotlin/SingleTest.kt
@@ -47,4 +47,13 @@ class SingleTest : KotlinTests() {
         Mockito.verify(a, Mockito.times(1))
                 .received("Hello World!")
     }
+    @Test
+    fun testSubscribeBy() {
+        Single.just("Alpha")
+                .subscribeBy {
+                    a.received(it)
+                }
+        verify(a, Mockito.times(1))
+                .received("Alpha")
+    }
 }


### PR DESCRIPTION
For some reason, the `onNext` and `onSuccess` parameters need to be the last ones to be the default if they are the only arguments provided without explicit name calls. This code below will not compile without these changes.

```kotlin
    Single.just("Alpha")
            .subscribeBy { s: String -> println(s) }
```