### PR TITLE
Update RxJava from 2.0.7 to 2.1.0

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -15,7 +15,7 @@ apply plugin: 'kotlin'
 apply plugin: 'java'
 
 dependencies {
-    compile 'io.reactivex.rxjava2:rxjava:2.0.7'
+    compile 'io.reactivex.rxjava2:rxjava:2.1.0'
     compile "org.jetbrains.kotlin:kotlin-stdlib:$kotlin_version"
     testCompile 'org.funktionale:funktionale-partials:1.0.0-final'
     testCompile 'junit:junit:4.12'


### PR DESCRIPTION
Update RxJava, to the latest version. It includes some bug fixes. As far as I checked, it does not contain any breaking changes. If I miss something, feel free to let me know.
https://github.com/ReactiveX/RxJava/releases/tag/v2.1.0