### PR TITLE
Fix Retrofit sample program does not work on 2.x branch

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -20,7 +20,9 @@ dependencies {
     testCompile 'org.funktionale:funktionale-partials:1.0.0-final'
     testCompile 'junit:junit:4.12'
     testCompile 'org.mockito:mockito-core:1.10.19'
-    examplesCompile 'com.squareup.retrofit:retrofit:1.9.+'
+    examplesCompile 'com.squareup.retrofit2:retrofit:2.3.0'
+    examplesCompile 'com.squareup.retrofit2:adapter-rxjava2:2.3.0'
+    examplesCompile 'com.squareup.retrofit2:converter-moshi:2.3.0'
 }
 
 task wrapper(type: Wrapper) {


### PR DESCRIPTION
# Abstract
This PR fixes `src/examples/retrofit/retrofit.kt` does not work on 2.x.

# Changes
- Introduce Retrofit2
- Introduce RxJava2 Adapter
- Introduce Moshi Converter for JSON parsing
- Remove unnecessary doOnAfterTerminate()