### PR TITLE
Bug fix on withLatestFrom (default Emit pair)

### DIFF
--- a/src/main/kotlin/io/reactivex/rxkotlin/Observables.kt
+++ b/src/main/kotlin/io/reactivex/rxkotlin/Observables.kt
@@ -154,7 +154,7 @@ inline fun <T, U, R> Observable<T>.withLatestFrom(other: ObservableSource<U>, cr
 /**
  * Emits a `Pair`
  */
-inline fun <T, U, R> Observable<T>.withLatestFrom(other: ObservableSource<U>): Observable<Pair<T,U>>
+inline fun <T, U> Observable<T>.withLatestFrom(other: ObservableSource<U>): Observable<Pair<T,U>>
         = withLatestFrom(other, BiFunction{ t, u -> Pair(t,u)  })
 
 /**

--- a/src/test/kotlin/io/reactivex/rxkotlin/ObservablesTest.kt
+++ b/src/test/kotlin/io/reactivex/rxkotlin/ObservablesTest.kt
@@ -1,0 +1,47 @@
+package io.reactivex.rxkotlin
+
+import io.reactivex.Observable
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+
+class ObservablesTest {
+    @Test fun testCombineLatestEmitPair() {
+        val pair = Pair(1, "a")
+        val result = Observables.combineLatest(
+            Observable.just(pair.first),
+            Observable.just(pair.second)
+        ).blockingFirst()
+
+        assertEquals(pair, result)
+    }
+
+    @Test fun testCombineLatestEmitTriple() {
+        val triple = Triple(1, "a", 1.0)
+        val result = Observables.combineLatest(
+            Observable.just(triple.first),
+            Observable.just(triple.second),
+            Observable.just(triple.third)
+        ).blockingFirst()
+
+        assertEquals(triple, result)
+    }
+
+    @Test fun testWithLatestFromEmitPair() {
+        val pair = Pair(1, "a")
+        val result = Observable.just(pair.first)
+                        .withLatestFrom(Observable.just(pair.second))
+                        .blockingFirst()
+
+        assertEquals(pair, result)
+    }
+
+    @Test fun testWithLatestFromEmitTriple(){
+        val triple = Triple(1, "a", 1.0)
+        val result = Observable.just(triple.first)
+                        .withLatestFrom(Observable.just(triple.second), Observable.just(triple.third))
+                        .blockingFirst()
+
+        assertEquals(triple, result)
+    }
+}


### PR DESCRIPTION
caused by redundant generic return type

<img width="748" alt="screen shot 2017-08-06 at 14 41 37" src="https://user-images.githubusercontent.com/5468398/29001215-70dac0f8-7ab5-11e7-9118-469318f9dfd9.png">
