### PR TITLE
Fix subscribeBy onError default to match RxJava

### DIFF
--- a/src/main/kotlin/io/reactivex/rxkotlin/subscribers.kt
+++ b/src/main/kotlin/io/reactivex/rxkotlin/subscribers.kt
@@ -2,10 +2,11 @@ package io.reactivex.rxkotlin
 
 import io.reactivex.*
 import io.reactivex.disposables.Disposable
-import java.lang.RuntimeException
+import io.reactivex.exceptions.OnErrorNotImplementedException
+import io.reactivex.plugins.RxJavaPlugins
 
 private val onNextStub: (Any) -> Unit = {}
-private val onErrorStub: (Throwable) -> Unit = { throw OnErrorNotImplementedException(it) }
+private val onErrorStub: (Throwable) -> Unit = { RxJavaPlugins.onError(OnErrorNotImplementedException(it)) }
 private val onCompleteStub: () -> Unit = {}
 
 /**
@@ -68,5 +69,3 @@ fun <T : Any> Flowable<T>.blockingSubscribeBy(
         onComplete: () -> Unit = onCompleteStub,
         onNext: (T) -> Unit = onNextStub
         ) = blockingSubscribe(onNext, onError, onComplete)
-
-class OnErrorNotImplementedException(e: Throwable) : RuntimeException(e)

--- a/src/test/kotlin/io/reactivex/rxkotlin/BasicKotlinTests.kt
+++ b/src/test/kotlin/io/reactivex/rxkotlin/BasicKotlinTests.kt
@@ -17,10 +17,11 @@
 package io.reactivex.rxkotlin
 
 import io.reactivex.*
+import io.reactivex.exceptions.OnErrorNotImplementedException
 import io.reactivex.functions.BiFunction
 import io.reactivex.functions.Function3
-import org.junit.Assert.assertEquals
-import org.junit.Assert.fail
+import io.reactivex.plugins.RxJavaPlugins
+import org.junit.Assert.*
 import org.junit.Test
 import org.mockito.Mockito.*
 import kotlin.concurrent.thread
@@ -39,6 +40,20 @@ class BasicKotlinTests : KotlinTests() {
         )
 
         verify(a, times(1)).received("Hello")
+    }
+
+    @Test fun testOnError() {
+        class TestException : RuntimeException()
+        val list = ArrayList<Throwable>()
+        RxJavaPlugins.setErrorHandler { list.add(it) }
+        try {
+            Observable.error<Any>(TestException()).subscribeBy()
+            assertEquals(1, list.size)
+            assertTrue(list[0] is OnErrorNotImplementedException)
+            assertTrue(list[0].cause is TestException)
+        } finally {
+            RxJavaPlugins.reset()
+        }
     }
 
     @Test fun testFilter() {


### PR DESCRIPTION
This fixes two problems with the current implementation of `onErrorStub`:

1. A custom `OnErrorNotImplementedException` was used instead of the standard one. This causes a couple of problems, but the main one is that the error handler doesn't know about the custom exception, so it gets wrapped in a `CompositeException`, which we don't want. 
2. The `onErrorStub` threw an exception directly instead of calling `RxJavaPlugins.error`. If you throw in `onError`, the `LambdaObserver` catches the exception and wraps it in another `CompositeException` before sending it to `RxJavaPlugins.error` anyway.