### PR TITLE
Add extension fuctions to concat Iterables

### DIFF
--- a/src/main/kotlin/io/reactivex/rxkotlin/completable.kt
+++ b/src/main/kotlin/io/reactivex/rxkotlin/completable.kt
@@ -27,6 +27,6 @@ fun  Observable<Completable>.mergeAllCompletables() = flatMapCompletable { it }
 fun  Flowable<Completable>.mergeAllCompletables() = flatMapCompletable { it }
 
 /**
- * Concats Iterable of completables into flowable. Same as calling `Completable.concat(this)`
+ * Concats an Iterable of completables into flowable. Same as calling `Completable.concat(this)`
  */
 fun Iterable<CompletableSource>.concatCompletables() = Completable.concat(this)

--- a/src/main/kotlin/io/reactivex/rxkotlin/completable.kt
+++ b/src/main/kotlin/io/reactivex/rxkotlin/completable.kt
@@ -29,4 +29,4 @@ fun  Flowable<Completable>.mergeAllCompletables() = flatMapCompletable { it }
 /**
  * Concats an Iterable of completables into flowable. Same as calling `Completable.concat(this)`
  */
-fun Iterable<CompletableSource>.concatCompletables() = Completable.concat(this)
+fun Iterable<CompletableSource>.concatAll() = Completable.concat(this)

--- a/src/main/kotlin/io/reactivex/rxkotlin/completable.kt
+++ b/src/main/kotlin/io/reactivex/rxkotlin/completable.kt
@@ -1,6 +1,7 @@
 package io.reactivex.rxkotlin
 
 import io.reactivex.Completable
+import io.reactivex.CompletableSource
 import io.reactivex.Flowable
 import io.reactivex.Observable
 import io.reactivex.functions.Action
@@ -24,3 +25,8 @@ fun  Observable<Completable>.mergeAllCompletables() = flatMapCompletable { it }
  * Merges the emissions of a Flowable<Completable>. Same as calling `flatMap { it }`.
  */
 fun  Flowable<Completable>.mergeAllCompletables() = flatMapCompletable { it }
+
+/**
+ * Concats Iterable of completables into flowable. Same as calling `Completable.concat(this)`
+ */
+fun Iterable<CompletableSource>.concatCompletables() = Completable.concat(this)

--- a/src/main/kotlin/io/reactivex/rxkotlin/flowable.kt
+++ b/src/main/kotlin/io/reactivex/rxkotlin/flowable.kt
@@ -114,4 +114,4 @@ fun <A: Any, B: Any> Flowable<Pair<A, B>>.toMultimap() = toMultimap({it.first},{
 /**
  * Concats an Iterable of flowables into flowable. Same as calling `Flowable.concat(this)`
  */
-fun <T : Any> Iterable<Publisher<T>>.concatFlowables() = Flowable.concat(this)
+fun <T : Any> Iterable<Publisher<T>>.concatAll() = Flowable.concat(this)

--- a/src/main/kotlin/io/reactivex/rxkotlin/flowable.kt
+++ b/src/main/kotlin/io/reactivex/rxkotlin/flowable.kt
@@ -3,6 +3,7 @@ package io.reactivex.rxkotlin
 import io.reactivex.Flowable
 import io.reactivex.functions.BiFunction
 import io.reactivex.functions.Function3
+import org.reactivestreams.Publisher
 
 
 fun BooleanArray.toFlowable(): Flowable<Boolean> = asIterable().toFlowable()
@@ -109,3 +110,8 @@ fun <A: Any, B: Any> Flowable<Pair<A, B>>.toMap() = toMap({it.first},{it.second}
  * Collects `Pair` emission into a multimap
  */
 fun <A: Any, B: Any> Flowable<Pair<A, B>>.toMultimap() = toMultimap({it.first},{it.second})
+
+/**
+ * Concats an Iterable of flowables into flowable. Same as calling `Flowable.concat(this)`
+ */
+fun <T : Any> Iterable<Publisher<T>>.concatFlowables() = Flowable.concat(this)

--- a/src/main/kotlin/io/reactivex/rxkotlin/maybe.kt
+++ b/src/main/kotlin/io/reactivex/rxkotlin/maybe.kt
@@ -32,4 +32,4 @@ fun <T : Any> Flowable<Maybe<T>>.mergeAllMaybes() = flatMapMaybe { it }
 /**
  * Concats an Iterable of maybes into flowable. Same as calling `Maybe.concat(this)`
  */
-fun <T : Any> Iterable<MaybeSource<T>>.concatMaybes() = Maybe.concat(this)
+fun <T : Any> Iterable<MaybeSource<T>>.concatAll() = Maybe.concat(this)

--- a/src/main/kotlin/io/reactivex/rxkotlin/maybe.kt
+++ b/src/main/kotlin/io/reactivex/rxkotlin/maybe.kt
@@ -30,6 +30,6 @@ fun <T : Any> Observable<Maybe<T>>.mergeAllMaybes() = flatMapMaybe { it }
 fun <T : Any> Flowable<Maybe<T>>.mergeAllMaybes() = flatMapMaybe { it }
 
 /**
- * Concats the emissions of an Iterable of maybes into flowable. Same as calling `Maybe.concat(this)`
+ * Concats an Iterable of maybes into flowable. Same as calling `Maybe.concat(this)`
  */
 fun <T : Any> Iterable<MaybeSource<T>>.concatMaybes() = Maybe.concat(this)

--- a/src/main/kotlin/io/reactivex/rxkotlin/maybe.kt
+++ b/src/main/kotlin/io/reactivex/rxkotlin/maybe.kt
@@ -2,6 +2,7 @@ package io.reactivex.rxkotlin
 
 import io.reactivex.Flowable
 import io.reactivex.Maybe
+import io.reactivex.MaybeSource
 import io.reactivex.Observable
 import java.util.concurrent.Callable
 import java.util.concurrent.Future
@@ -27,3 +28,8 @@ fun <T : Any> Observable<Maybe<T>>.mergeAllMaybes() = flatMapMaybe { it }
  * Merges the emissions of a Flowable<Maybe<T>>. Same as calling `flatMap { it }`.
  */
 fun <T : Any> Flowable<Maybe<T>>.mergeAllMaybes() = flatMapMaybe { it }
+
+/**
+ * Concats the emissions of an Iterable of maybes into flowable. Same as calling `Maybe.concat(this)`
+ */
+fun <T : Any> Iterable<MaybeSource<T>>.concatMaybes() = Maybe.concat(this)

--- a/src/main/kotlin/io/reactivex/rxkotlin/observable.kt
+++ b/src/main/kotlin/io/reactivex/rxkotlin/observable.kt
@@ -1,6 +1,7 @@
 package io.reactivex.rxkotlin
 
 import io.reactivex.Observable
+import io.reactivex.ObservableSource
 import io.reactivex.functions.BiFunction
 import io.reactivex.functions.Function3
 
@@ -102,3 +103,5 @@ fun <A: Any, B: Any> Observable<Pair<A,B>>.toMap() = toMap({it.first},{it.second
  * Collects `Pair` emission into a multimap
  */
 fun <A: Any, B: Any> Observable<Pair<A,B>>.toMultimap() = toMultimap({it.first},{it.second})
+
+fun  <T : Any> Iterable<ObservableSource<T>>.concatAll() = Observable.concat(this)

--- a/src/main/kotlin/io/reactivex/rxkotlin/single.kt
+++ b/src/main/kotlin/io/reactivex/rxkotlin/single.kt
@@ -3,6 +3,7 @@ package io.reactivex.rxkotlin
 import io.reactivex.Flowable
 import io.reactivex.Observable
 import io.reactivex.Single
+import io.reactivex.SingleSource
 import java.util.concurrent.Callable
 import java.util.concurrent.Future
 
@@ -25,3 +26,8 @@ fun <T : Any> Observable<Single<T>>.mergeAllSingles() = flatMapSingle { it }
  * Merges the emissions of a Flowable<Single<T>>. Same as calling `flatMap { it }`.
  */
 fun <T : Any> Flowable<Single<T>>.mergeAllSingles() = flatMapSingle { it }
+
+/**
+ * Concats the emissions of an Iterable of singles into flowable. Same as calling `Single.concat(this)`
+ */
+fun <T : Any> Iterable<SingleSource<T>>.concatSingles() = Single.concat(this)

--- a/src/main/kotlin/io/reactivex/rxkotlin/single.kt
+++ b/src/main/kotlin/io/reactivex/rxkotlin/single.kt
@@ -30,4 +30,4 @@ fun <T : Any> Flowable<Single<T>>.mergeAllSingles() = flatMapSingle { it }
 /**
  * Concats an Iterable of singles into flowable. Same as calling `Single.concat(this)`
  */
-fun <T : Any> Iterable<SingleSource<T>>.concatSingles() = Single.concat(this)
+fun <T : Any> Iterable<SingleSource<T>>.concatAll() = Single.concat(this)

--- a/src/main/kotlin/io/reactivex/rxkotlin/single.kt
+++ b/src/main/kotlin/io/reactivex/rxkotlin/single.kt
@@ -28,6 +28,6 @@ fun <T : Any> Observable<Single<T>>.mergeAllSingles() = flatMapSingle { it }
 fun <T : Any> Flowable<Single<T>>.mergeAllSingles() = flatMapSingle { it }
 
 /**
- * Concats the emissions of an Iterable of singles into flowable. Same as calling `Single.concat(this)`
+ * Concats an Iterable of singles into flowable. Same as calling `Single.concat(this)`
  */
 fun <T : Any> Iterable<SingleSource<T>>.concatSingles() = Single.concat(this)

--- a/src/test/kotlin/io/reactivex/rxkotlin/CompletableTest.kt
+++ b/src/test/kotlin/io/reactivex/rxkotlin/CompletableTest.kt
@@ -46,7 +46,7 @@ class CompletableTest {
         var list = emptyList<Int>()
         (0 until 10)
                 .map { v -> Completable.create { list += v } }
-                .concatCompletables()
+                .concatAll()
                 .subscribe {
                     Assert.assertEquals((0 until 10).toList(), list)
                 }

--- a/src/test/kotlin/io/reactivex/rxkotlin/CompletableTest.kt
+++ b/src/test/kotlin/io/reactivex/rxkotlin/CompletableTest.kt
@@ -42,7 +42,7 @@ class CompletableTest {
         c1.toObservable<String>().blockingFirst()
     }
 
-    @Test fun testConcatCompletables() {
+    @Test fun testConcatAll() {
         var list = emptyList<Int>()
         (0 until 10)
                 .map { v -> Completable.create { list += v } }

--- a/src/test/kotlin/io/reactivex/rxkotlin/CompletableTest.kt
+++ b/src/test/kotlin/io/reactivex/rxkotlin/CompletableTest.kt
@@ -1,7 +1,9 @@
 package io.reactivex.rxkotlin
 
+import io.reactivex.Completable
 import io.reactivex.Single
 import io.reactivex.functions.Action
+import org.junit.Assert
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertNotNull
 import org.junit.Test
@@ -38,6 +40,16 @@ class CompletableTest {
         val c1 = Single.just("Hello World!").toCompletable()
         assertNotNull(c1)
         c1.toObservable<String>().blockingFirst()
+    }
+
+    @Test fun testConcatCompletables() {
+        var list = emptyList<Int>()
+        (0 until 10)
+                .map { v -> Completable.create { list += v } }
+                .concatCompletables()
+                .subscribe {
+                    Assert.assertEquals((0 until 10).toList(), list)
+                }
     }
 
 }

--- a/src/test/kotlin/io/reactivex/rxkotlin/FlowableTest.kt
+++ b/src/test/kotlin/io/reactivex/rxkotlin/FlowableTest.kt
@@ -199,4 +199,14 @@ class FlowableTest {
 
         testSubscriber.assertValues(Triple("Alpha",1, 100), Triple("Beta",2, 200), Triple("Gamma",3, 300))
     }
+
+    @Test fun testConcatFlowables() {
+        (0 until 10)
+                .map { Flowable.just(it) }
+                .concatFlowables()
+                .toList()
+                .subscribe { result ->
+                    Assert.assertEquals((0 until 10).toList(), result)
+                }
+    }
 }

--- a/src/test/kotlin/io/reactivex/rxkotlin/FlowableTest.kt
+++ b/src/test/kotlin/io/reactivex/rxkotlin/FlowableTest.kt
@@ -203,7 +203,7 @@ class FlowableTest {
     @Test fun testConcatFlowables() {
         (0 until 10)
                 .map { Flowable.just(it) }
-                .concatFlowables()
+                .concatAll()
                 .toList()
                 .subscribe { result ->
                     Assert.assertEquals((0 until 10).toList(), result)

--- a/src/test/kotlin/io/reactivex/rxkotlin/FlowableTest.kt
+++ b/src/test/kotlin/io/reactivex/rxkotlin/FlowableTest.kt
@@ -200,7 +200,7 @@ class FlowableTest {
         testSubscriber.assertValues(Triple("Alpha",1, 100), Triple("Beta",2, 200), Triple("Gamma",3, 300))
     }
 
-    @Test fun testConcatFlowables() {
+    @Test fun testConcatAll() {
         (0 until 10)
                 .map { Flowable.just(it) }
                 .concatAll()

--- a/src/test/kotlin/io/reactivex/rxkotlin/MaybeTest.kt
+++ b/src/test/kotlin/io/reactivex/rxkotlin/MaybeTest.kt
@@ -20,7 +20,7 @@ class MaybeTest {
     @Test fun testConcatMaybes() {
         (0 until 10)
                 .map { Maybe.just(it) }
-                .concatMaybes()
+                .concatAll()
                 .toList()
                 .subscribe { result ->
                     Assert.assertEquals((0 until 10).toList(), result)

--- a/src/test/kotlin/io/reactivex/rxkotlin/MaybeTest.kt
+++ b/src/test/kotlin/io/reactivex/rxkotlin/MaybeTest.kt
@@ -16,4 +16,14 @@ class MaybeTest {
                 }
         Assert.assertTrue(first.get() == "Alpha")
     }
+
+    @Test fun testConcatMaybes() {
+        (0 until 10)
+                .map { Maybe.just(it) }
+                .concatMaybes()
+                .toList()
+                .subscribe { result ->
+                    Assert.assertEquals((0 until 10).toList(), result)
+                }
+    }
 }

--- a/src/test/kotlin/io/reactivex/rxkotlin/MaybeTest.kt
+++ b/src/test/kotlin/io/reactivex/rxkotlin/MaybeTest.kt
@@ -17,7 +17,7 @@ class MaybeTest {
         Assert.assertTrue(first.get() == "Alpha")
     }
 
-    @Test fun testConcatMaybes() {
+    @Test fun testConcatAll() {
         (0 until 10)
                 .map { Maybe.just(it) }
                 .concatAll()

--- a/src/test/kotlin/io/reactivex/rxkotlin/ObservableTest.kt
+++ b/src/test/kotlin/io/reactivex/rxkotlin/ObservableTest.kt
@@ -2,6 +2,7 @@ package io.reactivex.rxkotlin
 
 import io.reactivex.Observable
 import io.reactivex.observers.TestObserver
+import org.junit.Assert
 import org.junit.Assert.*
 import org.junit.Ignore
 import org.junit.Test
@@ -223,4 +224,14 @@ class ObservableTest {
         testObserver.assertValues(Triple("Alpha",1, 100), Triple("Beta",2, 200), Triple("Gamma",3, 300))
     }
 
+    @Test fun testConcatAll() {
+        var counter = 0
+        (0 until 10)
+                .map { Observable.just(counter++, counter++, counter++) }
+                .concatAll()
+                .toList()
+                .subscribe { result ->
+                    Assert.assertEquals((0 until 30).toList(), result)
+                }
+    }
 }

--- a/src/test/kotlin/io/reactivex/rxkotlin/SingleTest.kt
+++ b/src/test/kotlin/io/reactivex/rxkotlin/SingleTest.kt
@@ -58,7 +58,7 @@ class SingleTest : KotlinTests() {
                 .received("Alpha")
     }
 
-    @Test fun testConcatSingles() {
+    @Test fun testConcatAll() {
         (0 until 10)
                 .map { Single.just(it) }
                 .concatAll()

--- a/src/test/kotlin/io/reactivex/rxkotlin/SingleTest.kt
+++ b/src/test/kotlin/io/reactivex/rxkotlin/SingleTest.kt
@@ -61,7 +61,7 @@ class SingleTest : KotlinTests() {
     @Test fun testConcatSingles() {
         (0 until 10)
                 .map { Single.just(it) }
-                .concatSingles()
+                .concatAll()
                 .toList()
                 .subscribe { result ->
                     Assert.assertEquals((0 until 10).toList(), result)

--- a/src/test/kotlin/io/reactivex/rxkotlin/SingleTest.kt
+++ b/src/test/kotlin/io/reactivex/rxkotlin/SingleTest.kt
@@ -2,6 +2,7 @@ package io.reactivex.rxkotlin
 
 import io.reactivex.Observable
 import io.reactivex.Single
+import org.junit.Assert
 import org.junit.Test
 import org.mockito.Mockito
 import org.mockito.Mockito.mock
@@ -55,5 +56,15 @@ class SingleTest : KotlinTests() {
                 }
         verify(a, Mockito.times(1))
                 .received("Alpha")
+    }
+
+    @Test fun testConcatSingles() {
+        (0 until 10)
+                .map { Single.just(it) }
+                .concatSingles()
+                .toList()
+                .subscribe { result ->
+                    Assert.assertEquals((0 until 10).toList(), result)
+                }
     }
 }


### PR DESCRIPTION
Add extension fuctions to concat `Iterable<Single<T>>`, `Iterable<Maybe<T>>` and `Iterable<Completable>`.

Before:
```
Single.concat(videoTracks.map { ref.closeVideo(it) })
    .subscribe { println(it) }
```

After:
```
videoTracks
    .map { ref.closeVideo(it) }
    .concatSingles()
    .subscribe { println(it) }
```

Much more reactive =)