### PR TITLE
Add filterNot extension for Observable and Flowable receivers

### DIFF
--- a/src/main/kotlin/io/reactivex/rxkotlin/flowable.kt
+++ b/src/main/kotlin/io/reactivex/rxkotlin/flowable.kt
@@ -109,3 +109,16 @@ fun <A: Any, B: Any> Flowable<Pair<A, B>>.toMap() = toMap({it.first},{it.second}
  * Collects `Pair` emission into a multimap
  */
 fun <A: Any, B: Any> Flowable<Pair<A, B>>.toMultimap() = toMultimap({it.first},{it.second})
+
+
+/**
+ * Filters items emitted by a Publisher by only emitting those that does not satisfy a specified predicate.
+ *
+ * @param predicate
+ *            a function that evaluates each item emitted by the source Publisher, returning {@code true}
+ *            if it should not pass the filter
+ * @return a Flowable that emits only those items emitted by the source Publisher that the filter
+ *         evaluates as {@code false}
+ */
+fun <T> Flowable<T>.filterNot(predicate: (T) -> Boolean): Flowable<T>
+        = this.filter { !predicate(it) }

--- a/src/main/kotlin/io/reactivex/rxkotlin/observable.kt
+++ b/src/main/kotlin/io/reactivex/rxkotlin/observable.kt
@@ -102,3 +102,16 @@ fun <A: Any, B: Any> Observable<Pair<A,B>>.toMap() = toMap({it.first},{it.second
  * Collects `Pair` emission into a multimap
  */
 fun <A: Any, B: Any> Observable<Pair<A,B>>.toMultimap() = toMultimap({it.first},{it.second})
+
+/**
+ * Filters items emitted by an ObservableSource by only emitting those that does not satisfy a specified predicate.
+ *
+ * @param predicate
+ *            a function that evaluates each item emitted by the source ObservableSource, returning {@code true}
+ *            if it should not pass the filter
+ *
+ * @return an Observable that emits only those items emitted by the source ObservableSource that the filter
+ *         evaluates as {@code false}
+ */
+fun <T : Any> Observable<T>.filterNot(predicate: (T) -> Boolean): Observable<T>
+        = this.filter { !predicate(it) }

--- a/src/test/kotlin/io/reactivex/rxkotlin/FlowableTest.kt
+++ b/src/test/kotlin/io/reactivex/rxkotlin/FlowableTest.kt
@@ -4,6 +4,8 @@ import io.reactivex.BackpressureStrategy
 import io.reactivex.Flowable
 import io.reactivex.Flowable.create
 import io.reactivex.FlowableEmitter
+import io.reactivex.Observable
+import io.reactivex.observers.TestObserver
 import io.reactivex.subscribers.TestSubscriber
 import org.junit.Assert
 import org.junit.Assert.assertEquals
@@ -198,5 +200,16 @@ class FlowableTest {
         ).subscribe(testSubscriber)
 
         testSubscriber.assertValues(Triple("Alpha",1, 100), Triple("Beta",2, 200), Triple("Gamma",3, 300))
+    }
+
+    @Test
+    fun testFilterNot() {
+        val testObserver = TestSubscriber<String>()
+
+        Flowable.fromArray("foo", "bar", "lorem")
+                .filterNot { it == "bar"}
+                .subscribe(testObserver)
+
+        testObserver.assertValues("foo", "lorem")
     }
 }

--- a/src/test/kotlin/io/reactivex/rxkotlin/ObservableTest.kt
+++ b/src/test/kotlin/io/reactivex/rxkotlin/ObservableTest.kt
@@ -223,4 +223,15 @@ class ObservableTest {
         testObserver.assertValues(Triple("Alpha",1, 100), Triple("Beta",2, 200), Triple("Gamma",3, 300))
     }
 
+    @Test
+    fun testFilterNot() {
+        val testObserver = TestObserver<String>()
+
+        Observable.fromArray("foo", "bar", "lorem")
+                .filterNot { it == "bar"}
+                .subscribe(testObserver)
+
+        testObserver.assertValues("foo", "lorem")
+    }
+
 }


### PR DESCRIPTION
Defines `filterNot`extension for `Observable` and `Flowable` as receiver to get pair of opposite methods `filter`/`filterNot` as it's presented in kotlin stdlib