### PR TITLE
Support LambdaConsumerIntrospection in subscribeBy.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -15,7 +15,7 @@ apply plugin: 'kotlin'
 apply plugin: 'java'
 
 dependencies {
-    compile 'io.reactivex.rxjava2:rxjava:2.1.0'
+    compile 'io.reactivex.rxjava2:rxjava:2.1.6'
     compile "org.jetbrains.kotlin:kotlin-stdlib:$kotlin_version"
     testCompile 'org.funktionale:funktionale-partials:1.0.0-final'
     testCompile 'junit:junit:4.12'

--- a/src/main/kotlin/io/reactivex/rxkotlin/subscribers.kt
+++ b/src/main/kotlin/io/reactivex/rxkotlin/subscribers.kt
@@ -16,7 +16,13 @@ fun <T : Any> Observable<T>.subscribeBy(
         onError: (Throwable) -> Unit = onErrorStub,
         onComplete: () -> Unit = onCompleteStub,
         onNext: (T) -> Unit = onNextStub
-        ): Disposable = subscribe(onNext, onError, onComplete)
+        ): Disposable =
+        if (onComplete === onCompleteStub) {
+            if (onError === onErrorStub) subscribe(onNext)
+            else subscribe(onNext, onError)
+        } else {
+            subscribe(onNext, onError, onComplete)
+        }
 
 /**
  * Overloaded subscribe function that allows passing named parameters
@@ -25,7 +31,13 @@ fun <T : Any> Flowable<T>.subscribeBy(
         onError: (Throwable) -> Unit = onErrorStub,
         onComplete: () -> Unit = onCompleteStub,
         onNext: (T) -> Unit = onNextStub
-        ): Disposable = subscribe(onNext, onError, onComplete)
+        ): Disposable =
+        if (onComplete === onCompleteStub) {
+            if (onError === onErrorStub) subscribe(onNext)
+            else subscribe(onNext, onError)
+        } else {
+            subscribe(onNext, onError, onComplete)
+        }
 
 /**
  * Overloaded subscribe function that allows passing named parameters
@@ -33,7 +45,9 @@ fun <T : Any> Flowable<T>.subscribeBy(
 fun <T : Any> Single<T>.subscribeBy(
         onError: (Throwable) -> Unit = onErrorStub,
         onSuccess: (T) -> Unit = onNextStub
-        ): Disposable = subscribe(onSuccess, onError)
+        ): Disposable =
+        if (onError === onErrorStub) subscribe(onSuccess)
+        else subscribe(onSuccess, onError)
 
 /**
  * Overloaded subscribe function that allows passing named parameters
@@ -42,7 +56,13 @@ fun <T : Any> Maybe<T>.subscribeBy(
         onError: (Throwable) -> Unit = onErrorStub,
         onComplete: () -> Unit = onCompleteStub,
         onSuccess: (T) -> Unit = onNextStub
-        ): Disposable = subscribe(onSuccess, onError, onComplete)
+        ): Disposable =
+        if (onComplete === onCompleteStub) {
+            if (onError === onErrorStub) subscribe(onSuccess)
+            else subscribe(onSuccess, onError)
+        } else {
+            subscribe(onSuccess, onError, onComplete)
+        }
 
 /**
  * Overloaded subscribe function that allows passing named parameters
@@ -50,7 +70,9 @@ fun <T : Any> Maybe<T>.subscribeBy(
 fun Completable.subscribeBy(
         onError: (Throwable) -> Unit = onErrorStub,
         onComplete: () -> Unit = onCompleteStub
-): Disposable = subscribe(onComplete, onError)
+        ): Disposable =
+        if (onError === onErrorStub) subscribe(onComplete)
+        else subscribe(onComplete, onError)
 
 /**
  * Overloaded blockingSubscribe function that allows passing named parameters
@@ -59,7 +81,13 @@ fun <T : Any> Observable<T>.blockingSubscribeBy(
         onError: (Throwable) -> Unit = onErrorStub,
         onComplete: () -> Unit = onCompleteStub,
         onNext: (T) -> Unit = onNextStub
-        ) = blockingSubscribe(onNext, onError, onComplete)
+        ): Disposable =
+        if (onComplete === onCompleteStub) {
+            if (onError === onErrorStub) subscribe(onNext)
+            else subscribe(onNext, onError)
+        } else {
+            subscribe(onNext, onError, onComplete)
+        }
 
 /**
  * Overloaded blockingSubscribe function that allows passing named parameters
@@ -68,4 +96,10 @@ fun <T : Any> Flowable<T>.blockingSubscribeBy(
         onError: (Throwable) -> Unit = onErrorStub,
         onComplete: () -> Unit = onCompleteStub,
         onNext: (T) -> Unit = onNextStub
-        ) = blockingSubscribe(onNext, onError, onComplete)
+        ): Disposable =
+        if (onComplete === onCompleteStub) {
+            if (onError === onErrorStub) subscribe(onNext)
+            else subscribe(onNext, onError)
+        } else {
+            subscribe(onNext, onError, onComplete)
+        }

--- a/src/test/kotlin/io/reactivex/rxkotlin/CompletableTest.kt
+++ b/src/test/kotlin/io/reactivex/rxkotlin/CompletableTest.kt
@@ -3,14 +3,16 @@ package io.reactivex.rxkotlin
 import io.reactivex.Completable
 import io.reactivex.Single
 import io.reactivex.functions.Action
+import io.reactivex.observers.LambdaConsumerIntrospection
 import org.junit.Assert
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertNotNull
 import org.junit.Test
+import org.mockito.Mockito
 import java.util.*
 import java.util.concurrent.Callable
 
-class CompletableTest {
+class CompletableTest : KotlinTests() {
 
     @Test fun testCreateFromAction() {
         var count = 0
@@ -52,4 +54,27 @@ class CompletableTest {
                 }
     }
 
+    @Test
+    fun testSubscribeBy() {
+        Completable.complete()
+                .subscribeBy {
+                    a.received(Unit)
+                }
+        Mockito.verify(a, Mockito.times(1))
+                .received(Unit)
+    }
+
+    @Test
+    fun testSubscribeByErrorIntrospection() {
+        val disposable = Completable.complete()
+                .subscribeBy() as LambdaConsumerIntrospection
+        Assert.assertFalse(disposable.hasCustomOnError())
+    }
+
+    @Test
+    fun testSubscribeByErrorIntrospectionCustom() {
+        val disposable = Completable.complete()
+                .subscribeBy(onError = {}) as LambdaConsumerIntrospection
+        Assert.assertTrue(disposable.hasCustomOnError())
+    }
 }

--- a/src/test/kotlin/io/reactivex/rxkotlin/FlowableTest.kt
+++ b/src/test/kotlin/io/reactivex/rxkotlin/FlowableTest.kt
@@ -179,6 +179,14 @@ class FlowableTest {
     }
 
     @Test
+    @Ignore("Fix with adding support for LambdaConsumerIntrospection - #151")
+    fun testSubscribeByErrorIntrospectionDefaultWithOnComplete() {
+        val disposable = Flowable.just(Unit)
+                .subscribeBy(onComplete = {}) as LambdaConsumerIntrospection
+        Assert.assertFalse(disposable.hasCustomOnError())
+    }
+
+    @Test
     fun testBlockingSubscribeBy() {
         val first = AtomicReference<String>()
 

--- a/src/test/kotlin/io/reactivex/rxkotlin/FlowableTest.kt
+++ b/src/test/kotlin/io/reactivex/rxkotlin/FlowableTest.kt
@@ -179,7 +179,6 @@ class FlowableTest {
     }
 
     @Test
-    @Ignore("Fix with adding support for LambdaConsumerIntrospection - #151")
     fun testSubscribeByErrorIntrospectionDefaultWithOnComplete() {
         val disposable = Flowable.just(Unit)
                 .subscribeBy(onComplete = {}) as LambdaConsumerIntrospection

--- a/src/test/kotlin/io/reactivex/rxkotlin/FlowableTest.kt
+++ b/src/test/kotlin/io/reactivex/rxkotlin/FlowableTest.kt
@@ -4,6 +4,7 @@ import io.reactivex.BackpressureStrategy
 import io.reactivex.Flowable
 import io.reactivex.Flowable.create
 import io.reactivex.FlowableEmitter
+import io.reactivex.observers.LambdaConsumerIntrospection
 import io.reactivex.subscribers.TestSubscriber
 import org.junit.Assert
 import org.junit.Assert.assertEquals
@@ -161,6 +162,20 @@ class FlowableTest {
                     first.set(it)
                 }
         Assert.assertTrue(first.get() == "Alpha")
+    }
+
+    @Test
+    fun testSubscribeByErrorIntrospection() {
+        val disposable = Flowable.just(Unit)
+                .subscribeBy() as LambdaConsumerIntrospection
+        Assert.assertFalse(disposable.hasCustomOnError())
+    }
+
+    @Test
+    fun testSubscribeByErrorIntrospectionCustom() {
+        val disposable = Flowable.just(Unit)
+                .subscribeBy(onError = {}) as LambdaConsumerIntrospection
+        Assert.assertTrue(disposable.hasCustomOnError())
     }
 
     @Test

--- a/src/test/kotlin/io/reactivex/rxkotlin/MaybeTest.kt
+++ b/src/test/kotlin/io/reactivex/rxkotlin/MaybeTest.kt
@@ -1,6 +1,8 @@
 package io.reactivex.rxkotlin
 
 import io.reactivex.Maybe
+import io.reactivex.Single
+import io.reactivex.observers.LambdaConsumerIntrospection
 import org.junit.Assert
 import org.junit.Test
 import java.util.concurrent.atomic.AtomicReference
@@ -15,6 +17,20 @@ class MaybeTest {
                     first.set(it)
                 }
         Assert.assertTrue(first.get() == "Alpha")
+    }
+
+    @Test
+    fun testSubscribeByErrorIntrospection() {
+        val disposable = Single.just(Unit)
+                .subscribeBy() as LambdaConsumerIntrospection
+        Assert.assertFalse(disposable.hasCustomOnError())
+    }
+
+    @Test
+    fun testSubscribeByErrorIntrospectionCustom() {
+        val disposable = Single.just(Unit)
+                .subscribeBy(onError = {}) as LambdaConsumerIntrospection
+        Assert.assertTrue(disposable.hasCustomOnError())
     }
 
     @Test fun testConcatAll() {

--- a/src/test/kotlin/io/reactivex/rxkotlin/ObservableTest.kt
+++ b/src/test/kotlin/io/reactivex/rxkotlin/ObservableTest.kt
@@ -202,6 +202,14 @@ class ObservableTest {
     }
 
     @Test
+    @Ignore("Fix with adding support for LambdaConsumerIntrospection - #151")
+    fun testSubscribeByErrorIntrospectionDefaultWithOnComplete() {
+        val disposable = Observable.just(Unit)
+                .subscribeBy(onComplete = {}) as LambdaConsumerIntrospection
+        assertFalse(disposable.hasCustomOnError())
+    }
+
+    @Test
     fun testBlockingSubscribeBy() {
         val first = AtomicReference<String>()
 

--- a/src/test/kotlin/io/reactivex/rxkotlin/ObservableTest.kt
+++ b/src/test/kotlin/io/reactivex/rxkotlin/ObservableTest.kt
@@ -1,6 +1,7 @@
 package io.reactivex.rxkotlin
 
 import io.reactivex.Observable
+import io.reactivex.observers.LambdaConsumerIntrospection
 import io.reactivex.observers.TestObserver
 import org.junit.Assert
 import org.junit.Assert.*
@@ -184,6 +185,20 @@ class ObservableTest {
                     first.set(it)
                 }
         assertTrue(first.get() == "Alpha")
+    }
+
+    @Test
+    fun testSubscribeByErrorIntrospection() {
+        val disposable = Observable.just(Unit)
+                .subscribeBy() as LambdaConsumerIntrospection
+        assertFalse(disposable.hasCustomOnError())
+    }
+
+    @Test
+    fun testSubscribeByErrorIntrospectionCustom() {
+        val disposable = Observable.just(Unit)
+                .subscribeBy(onError = {}) as LambdaConsumerIntrospection
+        assertTrue(disposable.hasCustomOnError())
     }
 
     @Test

--- a/src/test/kotlin/io/reactivex/rxkotlin/SingleTest.kt
+++ b/src/test/kotlin/io/reactivex/rxkotlin/SingleTest.kt
@@ -1,6 +1,7 @@
 package io.reactivex.rxkotlin
 
 import io.reactivex.Single
+import io.reactivex.observers.LambdaConsumerIntrospection
 import org.junit.Assert
 import org.junit.Test
 import org.mockito.Mockito
@@ -24,6 +25,20 @@ class SingleTest : KotlinTests() {
                 }
         verify(a, Mockito.times(1))
                 .received("Alpha")
+    }
+
+    @Test
+    fun testSubscribeByErrorIntrospection() {
+        val disposable = Single.just(Unit)
+                .subscribeBy() as LambdaConsumerIntrospection
+        Assert.assertFalse(disposable.hasCustomOnError())
+    }
+
+    @Test
+    fun testSubscribeByErrorIntrospectionCustom() {
+        val disposable = Single.just(Unit)
+                .subscribeBy(onError = {}) as LambdaConsumerIntrospection
+        Assert.assertTrue(disposable.hasCustomOnError())
     }
 
     @Test fun testConcatAll() {


### PR DESCRIPTION
ReactiveX/RxJava#5590 added the `LambdaConsumerIntrospection` interface to its `Disposable` implementations. That interface [is implemented](https://github.com/ReactiveX/RxJava/blob/3f9ffae961506ba560a8d43e936a94eb5f563d3c/src/main/java/io/reactivex/internal/subscribers/LambdaSubscriber.java#L124) by checking that the `onError` consumer is exactly the internal `ON_ERROR_MISSING` object. Since the `onErrorStub` that `subscribeBy` uses isn't that object, `hasCustomOnError` will always return false.

I'm currently fixing this by calling the different overloads of `subscribe` instead of passing in the stubs. I think it's the simplest way to fix the problem, but it does feel a bit kludgy, so I'm open to suggestions.

This PR also updates the RxJava dependency to 2.1.6 to give tests access to `LambdaConsumerIntrospection`.

