### PR TITLE
Pin gradle dependency version.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -2,8 +2,8 @@ buildscript {
     ext.kotlin_version = '1.1.51'
     repositories { jcenter() }
     dependencies {
-        classpath 'com.netflix.nebula:gradle-rxjava-project-plugin:4.+',
-                "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
+        classpath 'com.netflix.nebula:gradle-rxjava-project-plugin:4.0.0'
+        classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
     }
 }
 


### PR DESCRIPTION
The neblua plugin dependency was using an unpinned version, which forces gradle to query the maven repo on every build. Given that the plugin hasn't had a release in almost two years, I think it's safe to declare the version explicitly.