### PR TITLE
Make composite disposable extensions work on DisposableContainer instead

### DIFF
--- a/src/main/kotlin/io/reactivex/rxkotlin/disposable.kt
+++ b/src/main/kotlin/io/reactivex/rxkotlin/disposable.kt
@@ -1,12 +1,12 @@
 package io.reactivex.rxkotlin
 
-import io.reactivex.disposables.CompositeDisposable
 import io.reactivex.disposables.Disposable
+import io.reactivex.internal.disposables.DisposableContainer
 
 /**
  * disposable += observable.subscribe()
  */
-operator fun CompositeDisposable.plusAssign(disposable: Disposable) {
+operator fun DisposableContainer.plusAssign(disposable: Disposable) {
     add(disposable)
 }
 
@@ -15,5 +15,5 @@ operator fun CompositeDisposable.plusAssign(disposable: Disposable) {
  * @param compositeDisposable CompositeDisposable to add this disposable to
  * @return this instance
  */
-fun Disposable.addTo(compositeDisposable: CompositeDisposable): Disposable
-        = apply { compositeDisposable.add(this) }
+fun Disposable.addTo(disposableContainer: DisposableContainer): Disposable
+        = apply { disposableContainer.add(this) }


### PR DESCRIPTION
`CompositeDisposable` is one implementation of `DisposableContainer`, another is `ListCompositeDisposable`.
Fix: extension methods work for both implementations.