### PR TITLE
Added Observables.combineLatest for Iterable

### DIFF
--- a/src/main/kotlin/io/reactivex/rxkotlin/Observables.kt
+++ b/src/main/kotlin/io/reactivex/rxkotlin/Observables.kt
@@ -74,6 +74,9 @@ object Observables {
             Observable.combineLatest(source1, source2,source3, source4, source5, source6, source7, source8, source9,
                     Function9 { t1: T1, t2: T2, t3: T3, t4: T4, t5: T5, t6: T6, t7: T7, t8: T8, t9: T9 -> combineFunction(t1,t2, t3, t4, t5, t6, t7, t8, t9) })!!
 
+    @Suppress("UNCHECKED_CAST")
+    inline fun <T, R> combineLatest(source: Iterable<Observable<T>>, crossinline combineFunction: (List<T>) -> R) =
+            Observable.combineLatest(source, { t -> combineFunction(t.map { it as T }) })!!
 
     
     

--- a/src/test/kotlin/io/reactivex/rxkotlin/ObservablesTest.kt
+++ b/src/test/kotlin/io/reactivex/rxkotlin/ObservablesTest.kt
@@ -3,6 +3,7 @@ package io.reactivex.rxkotlin
 import io.reactivex.Observable
 import org.junit.Assert.assertEquals
 import org.junit.Test
+import java.util.concurrent.TimeUnit
 
 
 class ObservablesTest {
@@ -25,6 +26,23 @@ class ObservablesTest {
         ).blockingFirst()
 
         assertEquals(triple, result)
+    }
+
+    @Test fun testCombineLatestIterable() {
+        val iterable = listOf<Observable<Int>>(
+                Observable.just(1),
+                Observable.just(2),
+                Observable.just(100, 200, 300)
+        )
+        Observables
+                .combineLatest(iterable) { it.toSet() }
+                .test()
+                .awaitDone(100, TimeUnit.MILLISECONDS)
+                .assertResult(
+                        listOf(1, 2, 100).toSet(),
+                        listOf(1, 2, 200).toSet(),
+                        listOf(1, 2, 300).toSet()
+                )
     }
 
     @Test fun testWithLatestFromEmitPair() {


### PR DESCRIPTION
There's no adapter to support [`Observable.combineLatest(iterable,Function)`](http://reactivex.io/RxJava/2.x/javadoc/io/reactivex/Observable.html#combineLatest-java.lang.Iterable-io.reactivex.functions.Function-).
It is useful because RxJava's implementation is not type safe (`Function<? super Object[], ? extends R>`).