### PR TITLE
Make cast and ofType operate on wildcard types rather than Any

### DIFF
--- a/src/main/kotlin/io/reactivex/rxkotlin/maybe.kt
+++ b/src/main/kotlin/io/reactivex/rxkotlin/maybe.kt
@@ -6,8 +6,8 @@ import io.reactivex.MaybeSource
 import io.reactivex.Observable
 
 
-inline fun <reified R : Any> Maybe<Any>.cast(): Maybe<R> = cast(R::class.java)
-inline fun <reified R : Any> Maybe<Any>.ofType(): Maybe<R> = ofType(R::class.java)
+inline fun <reified R : Any> Maybe<*>.cast(): Maybe<R> = cast(R::class.java)
+inline fun <reified R : Any> Maybe<*>.ofType(): Maybe<R> = ofType(R::class.java)
 
 
 

--- a/src/main/kotlin/io/reactivex/rxkotlin/single.kt
+++ b/src/main/kotlin/io/reactivex/rxkotlin/single.kt
@@ -5,7 +5,7 @@ import io.reactivex.Observable
 import io.reactivex.Single
 import io.reactivex.SingleSource
 
-inline fun <reified R : Any> Single<Any>.cast(): Single<R> = cast(R::class.java)
+inline fun <reified R : Any> Single<*>.cast(): Single<R> = cast(R::class.java)
 
 
 // EXTENSION FUNCTION OPERATORS


### PR DESCRIPTION
`Maybe.ofType`, `Maybe.cast` and `Single.cast` are declared as extensions on `Maybe<Any>/Single<Any>` rather than on `Maybe<*>/Single<*>` which prevents them from being used in some cases.

This PR fixes this and will align them with how the Observable and Flowable extensions are implemented.

This would be a binary compatible change and all existing consumers wouldn't need to change anything.