### PR TITLE
Improve applying SIP with plusAssign/addTo

### DIFF
--- a/src/main/kotlin/io/reactivex/rxkotlin/disposable.kt
+++ b/src/main/kotlin/io/reactivex/rxkotlin/disposable.kt
@@ -1,19 +1,19 @@
 package io.reactivex.rxkotlin
 
-import io.reactivex.disposables.CompositeDisposable
 import io.reactivex.disposables.Disposable
+import io.reactivex.internal.disposables.DisposableContainer
 
 /**
  * disposable += observable.subscribe()
  */
-operator fun CompositeDisposable.plusAssign(disposable: Disposable) {
+operator fun DisposableContainer.plusAssign(disposable: Disposable) {
     add(disposable)
 }
 
 /**
- * Add the disposable to a CompositeDisposable.
- * @param compositeDisposable CompositeDisposable to add this disposable to
+ * Add the disposable to a DisposableContainer.
+ * @param disposableContainer DisposableContainer to add this disposable to
  * @return this instance
  */
-fun Disposable.addTo(compositeDisposable: CompositeDisposable): Disposable
-        = apply { compositeDisposable.add(this) }
+fun Disposable.addTo(disposableContainer: DisposableContainer): Disposable
+        = apply { disposableContainer.add(this) }


### PR DESCRIPTION
Requiring `CompositeDisposable` for `plusAssign` and `addTo` is not
necessary. In fact, it gets developers into awkward position if they
wanted to apply interface segregation principle. The current
implementation forces to use `CompositeDisposable` even if the component
using the object doesn't need `Disposable` methods (`dispose`,
`isDisposed`). In a majority of components, plain `DisposableContainer`
is enough.
E.g. an activity creates and manage `CompositeDisposable`. All
ActivityScoped components get a `DisposableContainer`. This way it is
safer that only the activity can clear the container. With existing
implementation, the developer doesn't have a choice - he/she have to
pass `CompositeDisposable` to `ActivityScoped` components or use casting
to fulfil assignPlus/addTo interface.

Despite this is an interface change, every existing code that depends on
those methods will behave and work precisely the same. The difference is
that developers will gain options of writing code smarter.