### PR TITLE
Add zero-arg flatMapIterable and concatMapIterable

### DIFF
--- a/src/main/kotlin/io/reactivex/rxkotlin/observable.kt
+++ b/src/main/kotlin/io/reactivex/rxkotlin/observable.kt
@@ -25,6 +25,9 @@ fun <T : Any> Sequence<T>.toObservable(): Observable<T> = asIterable().toObserva
 fun <T : Any> Iterable<Observable<out T>>.merge(): Observable<T> = Observable.merge(this.toObservable())
 fun <T : Any> Iterable<Observable<out T>>.mergeDelayError(): Observable<T> = Observable.mergeDelayError(this.toObservable())
 
+fun <T : Any> Observable<out Iterable<T>>.flatMapIterable(): Observable<T> = flatMapIterable { it }
+fun <T : Any> Observable<out Iterable<T>>.concatMapIterable(): Observable<T> = concatMapIterable { it }
+
 /**
  * Returns Observable that emits objects from kotlin [Sequence] returned by function you provided by parameter [body] for
  * each input object and merges all produced elements into one observable.

--- a/src/test/kotlin/io/reactivex/rxkotlin/ObservableTest.kt
+++ b/src/test/kotlin/io/reactivex/rxkotlin/ObservableTest.kt
@@ -117,6 +117,20 @@ class ObservableTest {
         )
     }
 
+    @Test fun testFlatMapIterable() {
+        assertEquals(
+                listOf(1, 2, 3),
+                Observable.just(listOf(1, 2, 3)).flatMapIterable().toList().blockingGet()
+        )
+    }
+
+    @Test fun testConcatMapIterable() {
+        assertEquals(
+                listOf(1, 2, 3, 4),
+                Observable.just(listOf(1, 2, 3) , listOf(4)).concatMapIterable().toList().blockingGet()
+        )
+    }
+
     @Test fun testCombineLatest() {
         val list = listOf(1, 2, 3, 2, 3, 4, 3, 4, 5)
         assertEquals(list, list.map { Observable.just(it) }.combineLatest { it }.blockingFirst())


### PR DESCRIPTION
Implements https://github.com/ReactiveX/RxKotlin/issues/186

This introduces a convenient overload of `flatMapIterable` and `concatMapIterable` that allows the often-used `flatMapIterable { it }` to be abbreviated as `flatMapIterable()` and similarly for `concatMapIterable`.

This can save a number of classes and methods in an Android application.