### PR TITLE
Fix extensions to fail in compile time on nullable types

### DIFF
--- a/src/main/kotlin/io/reactivex/rxkotlin/Flowables.kt
+++ b/src/main/kotlin/io/reactivex/rxkotlin/Flowables.kt
@@ -18,7 +18,7 @@ object Flowables {
     @CheckReturnValue
     @BackpressureSupport(BackpressureKind.FULL)
     @SchedulerSupport(SchedulerSupport.NONE)
-    inline fun <T1,T2,R> combineLatest(source1: Flowable<T1>, source2: Flowable<T2>, crossinline combineFunction: (T1, T2) -> R) =
+    inline fun <T1 : Any, T2 : Any, R : Any> combineLatest(source1: Flowable<T1>, source2: Flowable<T2>, crossinline combineFunction: (T1, T2) -> R) =
             Flowable.combineLatest(source1, source2,
                     BiFunction<T1, T2, R> { t1, t2 -> combineFunction(t1,t2) })!!
 
@@ -28,7 +28,7 @@ object Flowables {
     @CheckReturnValue
     @BackpressureSupport(BackpressureKind.FULL)
     @SchedulerSupport(SchedulerSupport.NONE)
-    fun <T1,T2> combineLatest(source1: Flowable<T1>, source2: Flowable<T2>) =
+    fun <T1 : Any, T2 : Any> combineLatest(source1: Flowable<T1>, source2: Flowable<T2>) =
             Flowable.combineLatest(source1, source2,
                     BiFunction<T1, T2, Pair<T1,T2>> { t1, t2 -> t1 to t2 })!!
 
@@ -36,7 +36,7 @@ object Flowables {
     @CheckReturnValue
     @BackpressureSupport(BackpressureKind.FULL)
     @SchedulerSupport(SchedulerSupport.NONE)
-    inline fun <T1,T2,T3,R> combineLatest(source1: Flowable<T1>, source2: Flowable<T2>, source3: Flowable<T3>, crossinline combineFunction: (T1,T2, T3) -> R) =
+    inline fun <T1 : Any, T2 : Any, T3 : Any, R : Any> combineLatest(source1: Flowable<T1>, source2: Flowable<T2>, source3: Flowable<T3>, crossinline combineFunction: (T1,T2, T3) -> R) =
             Flowable.combineLatest(source1, source2,source3,
                     Function3{ t1: T1, t2: T2, t3: T3 -> combineFunction(t1,t2, t3) })!!
 
@@ -46,7 +46,7 @@ object Flowables {
     @CheckReturnValue
     @BackpressureSupport(BackpressureKind.FULL)
     @SchedulerSupport(SchedulerSupport.NONE)
-    fun <T1,T2,T3> combineLatest(source1: Flowable<T1>, source2: Flowable<T2>, source3: Flowable<T3>) =
+    fun <T1 : Any, T2 : Any, T3 : Any> combineLatest(source1: Flowable<T1>, source2: Flowable<T2>, source3: Flowable<T3>) =
             Flowable.combineLatest(source1, source2, source3,
                     Function3<T1, T2, T3, Triple<T1,T2,T3>> { t1, t2, t3 -> Triple(t1,t2,t3) })!!
 
@@ -54,7 +54,7 @@ object Flowables {
     @CheckReturnValue
     @BackpressureSupport(BackpressureKind.FULL)
     @SchedulerSupport(SchedulerSupport.NONE)
-    inline fun <T1,T2,T3,T4,R> combineLatest(source1: Flowable<T1>, source2: Flowable<T2>, source3: Flowable<T3>,
+    inline fun <T1 : Any, T2 : Any, T3 : Any, T4 : Any, R : Any> combineLatest(source1: Flowable<T1>, source2: Flowable<T2>, source3: Flowable<T3>,
                                              source4: Flowable<T4>, crossinline combineFunction: (T1,T2, T3, T4) -> R) =
             Flowable.combineLatest(source1, source2,source3, source4,
                     Function4 { t1: T1, t2: T2, t3: T3, t4: T4 -> combineFunction(t1,t2, t3, t4) })!!
@@ -63,7 +63,7 @@ object Flowables {
     @CheckReturnValue
     @BackpressureSupport(BackpressureKind.FULL)
     @SchedulerSupport(SchedulerSupport.NONE)
-    inline fun <T1,T2,T3,T4,T5,R> combineLatest(source1: Flowable<T1>, source2: Flowable<T2>,
+    inline fun <T1 : Any, T2 : Any, T3 : Any, T4 : Any, T5 : Any, R : Any> combineLatest(source1: Flowable<T1>, source2: Flowable<T2>,
                                                 source3: Flowable<T3>, source4: Flowable<T4>,
                                                 source5: Flowable<T5>, crossinline combineFunction: (T1,T2, T3, T4, T5) -> R) =
             Flowable.combineLatest(source1, source2,source3, source4, source5,
@@ -73,7 +73,7 @@ object Flowables {
     @CheckReturnValue
     @BackpressureSupport(BackpressureKind.FULL)
     @SchedulerSupport(SchedulerSupport.NONE)
-    inline fun <T1,T2,T3,T4,T5,T6,R> combineLatest(source1: Flowable<T1>, source2: Flowable<T2>,
+    inline fun <T1 : Any, T2 : Any, T3 : Any, T4 : Any, T5 : Any, T6 : Any, R : Any> combineLatest(source1: Flowable<T1>, source2: Flowable<T2>,
                                                    source3: Flowable<T3>, source4: Flowable<T4>,
                                                    source5: Flowable<T5>, source6: Flowable<T6>, crossinline combineFunction: (T1,T2, T3, T4, T5, T6) -> R) =
             Flowable.combineLatest(source1, source2,source3, source4, source5, source6,
@@ -82,7 +82,7 @@ object Flowables {
     @CheckReturnValue
     @BackpressureSupport(BackpressureKind.FULL)
     @SchedulerSupport(SchedulerSupport.NONE)
-    inline fun <T1,T2,T3,T4,T5,T6,T7,R> combineLatest(source1: Flowable<T1>, source2: Flowable<T2>,
+    inline fun <T1 : Any, T2 : Any, T3 : Any, T4 : Any, T5 : Any, T6 : Any, T7 : Any, R : Any> combineLatest(source1: Flowable<T1>, source2: Flowable<T2>,
                                                       source3: Flowable<T3>, source4: Flowable<T4>,
                                                       source5: Flowable<T5>, source6: Flowable<T6>,
                                                       source7: Flowable<T7>, crossinline combineFunction: (T1,T2, T3, T4, T5, T6, T7) -> R) =
@@ -93,7 +93,7 @@ object Flowables {
     @CheckReturnValue
     @BackpressureSupport(BackpressureKind.FULL)
     @SchedulerSupport(SchedulerSupport.NONE)
-    inline fun <T1,T2,T3,T4,T5,T6,T7,T8,R> combineLatest(source1: Flowable<T1>, source2: Flowable<T2>,
+    inline fun <T1 : Any, T2 : Any, T3 : Any, T4 : Any, T5 : Any, T6 : Any, T7 : Any, T8 : Any, R : Any> combineLatest(source1: Flowable<T1>, source2: Flowable<T2>,
                                                          source3: Flowable<T3>, source4: Flowable<T4>,
                                                          source5: Flowable<T5>, source6: Flowable<T6>,
                                                          source7: Flowable<T7>, source8: Flowable<T8>,
@@ -104,7 +104,7 @@ object Flowables {
     @CheckReturnValue
     @BackpressureSupport(BackpressureKind.FULL)
     @SchedulerSupport(SchedulerSupport.NONE)
-    inline fun <T1,T2,T3,T4,T5,T6,T7,T8,T9,R> combineLatest(source1: Flowable<T1>, source2: Flowable<T2>,
+    inline fun <T1 : Any, T2 : Any, T3 : Any, T4 : Any, T5 : Any, T6 : Any, T7 : Any, T8 : Any, T9 : Any, R : Any> combineLatest(source1: Flowable<T1>, source2: Flowable<T2>,
                                                             source3: Flowable<T3>, source4: Flowable<T4>,
                                                             source5: Flowable<T5>, source6: Flowable<T6>,
                                                             source7: Flowable<T7>, source8: Flowable<T8>,
@@ -118,7 +118,7 @@ object Flowables {
     @CheckReturnValue
     @BackpressureSupport(BackpressureKind.SPECIAL)
     @SchedulerSupport(SchedulerSupport.NONE)
-    inline fun <T> create(mode: BackpressureStrategy, crossinline source: (FlowableEmitter<T>) -> Unit) =
+    inline fun <T : Any> create(mode: BackpressureStrategy, crossinline source: (FlowableEmitter<T>) -> Unit) =
             Flowable.create<T>({ source(it) }, mode)!!
 
 
@@ -127,7 +127,7 @@ object Flowables {
     @CheckReturnValue
     @BackpressureSupport(BackpressureKind.FULL)
     @SchedulerSupport(SchedulerSupport.NONE)
-    inline fun <T1,T2,R> zip(source1: Flowable<T1>, source2: Flowable<T2>, crossinline combineFunction: (T1, T2) -> R) =
+    inline fun <T1 : Any, T2 : Any, R : Any> zip(source1: Flowable<T1>, source2: Flowable<T2>, crossinline combineFunction: (T1, T2) -> R) =
             Flowable.zip(source1, source2,
                     BiFunction<T1, T2, R> { t1, t2 -> combineFunction(t1,t2) })!!
 
@@ -137,7 +137,7 @@ object Flowables {
     @CheckReturnValue
     @BackpressureSupport(BackpressureKind.FULL)
     @SchedulerSupport(SchedulerSupport.NONE)
-    fun <T1,T2> zip(source1: Flowable<T1>, source2: Flowable<T2>) =
+    fun <T1 : Any, T2 : Any> zip(source1: Flowable<T1>, source2: Flowable<T2>) =
             Flowable.zip(source1, source2,
                     BiFunction<T1, T2, Pair<T1,T2>> { t1, t2 -> t1 to t2 })!!
 
@@ -145,7 +145,7 @@ object Flowables {
     @CheckReturnValue
     @BackpressureSupport(BackpressureKind.FULL)
     @SchedulerSupport(SchedulerSupport.NONE)
-    inline fun <T1,T2,T3,R> zip(source1: Flowable<T1>, source2: Flowable<T2>, source3: Flowable<T3>, crossinline combineFunction: (T1,T2, T3) -> R) =
+    inline fun <T1 : Any, T2 : Any, T3 : Any, R : Any> zip(source1: Flowable<T1>, source2: Flowable<T2>, source3: Flowable<T3>, crossinline combineFunction: (T1,T2, T3) -> R) =
             Flowable.zip(source1, source2,source3,
                     Function3 { t1: T1, t2: T2, t3: T3 -> combineFunction(t1,t2, t3) })!!
 
@@ -155,21 +155,21 @@ object Flowables {
     @CheckReturnValue
     @BackpressureSupport(BackpressureKind.FULL)
     @SchedulerSupport(SchedulerSupport.NONE)
-    fun <T1,T2,T3> zip(source1: Flowable<T1>, source2: Flowable<T2>, source3: Flowable<T3>) =
+    fun <T1 : Any, T2 : Any, T3 : Any> zip(source1: Flowable<T1>, source2: Flowable<T2>, source3: Flowable<T3>) =
             Flowable.zip(source1, source2, source3,
                     Function3<T1, T2, T3, Triple<T1,T2,T3>> { t1, t2, t3 -> Triple(t1,t2,t3) })!!
 
     @CheckReturnValue
     @BackpressureSupport(BackpressureKind.FULL)
     @SchedulerSupport(SchedulerSupport.NONE)
-    inline fun <T1,T2,T3,T4,R> zip(source1: Flowable<T1>, source2: Flowable<T2>, source3: Flowable<T3>, source4: Flowable<T4>, crossinline combineFunction: (T1,T2, T3, T4) -> R) =
+    inline fun <T1 : Any, T2 : Any, T3 : Any, T4 : Any, R : Any> zip(source1: Flowable<T1>, source2: Flowable<T2>, source3: Flowable<T3>, source4: Flowable<T4>, crossinline combineFunction: (T1,T2, T3, T4) -> R) =
             Flowable.zip(source1, source2,source3, source4,
                     Function4 { t1: T1, t2: T2, t3: T3, t4: T4 -> combineFunction(t1,t2, t3, t4) })!!
 
     @CheckReturnValue
     @BackpressureSupport(BackpressureKind.FULL)
     @SchedulerSupport(SchedulerSupport.NONE)
-    inline fun <T1,T2,T3,T4,T5,R> zip(source1: Flowable<T1>, source2: Flowable<T2>,
+    inline fun <T1 : Any, T2 : Any, T3 : Any, T4 : Any, T5 : Any, R : Any> zip(source1: Flowable<T1>, source2: Flowable<T2>,
                                       source3: Flowable<T3>, source4: Flowable<T4>,
                                       source5: Flowable<T5>, crossinline combineFunction: (T1,T2, T3, T4, T5) -> R) =
             Flowable.zip(source1, source2,source3, source4, source5,
@@ -180,7 +180,7 @@ object Flowables {
     @CheckReturnValue
     @BackpressureSupport(BackpressureKind.FULL)
     @SchedulerSupport(SchedulerSupport.NONE)
-    inline fun <T1,T2,T3,T4,T5,T6,R> zip(source1: Flowable<T1>, source2: Flowable<T2>,
+    inline fun <T1 : Any, T2 : Any, T3 : Any, T4 : Any, T5 : Any, T6 : Any, R : Any> zip(source1: Flowable<T1>, source2: Flowable<T2>,
                                          source3: Flowable<T3>, source4: Flowable<T4>,
                                          source5: Flowable<T5>, source6: Flowable<T6>, crossinline combineFunction: (T1,T2, T3, T4, T5, T6) -> R) =
             Flowable.zip(source1, source2,source3, source4, source5, source6,
@@ -189,7 +189,7 @@ object Flowables {
     @CheckReturnValue
     @BackpressureSupport(BackpressureKind.FULL)
     @SchedulerSupport(SchedulerSupport.NONE)
-    inline fun <T1,T2,T3,T4,T5,T6,T7,R> zip(source1: Flowable<T1>, source2: Flowable<T2>,
+    inline fun <T1 : Any, T2 : Any, T3 : Any, T4 : Any, T5 : Any, T6 : Any, T7 : Any, R : Any> zip(source1: Flowable<T1>, source2: Flowable<T2>,
                                             source3: Flowable<T3>, source4: Flowable<T4>,
                                             source5: Flowable<T5>, source6: Flowable<T6>,
                                             source7: Flowable<T7>, crossinline combineFunction: (T1,T2, T3, T4, T5, T6, T7) -> R) =
@@ -200,7 +200,7 @@ object Flowables {
     @CheckReturnValue
     @BackpressureSupport(BackpressureKind.FULL)
     @SchedulerSupport(SchedulerSupport.NONE)
-    inline fun <T1,T2,T3,T4,T5,T6,T7,T8,R> zip(source1: Flowable<T1>, source2: Flowable<T2>,
+    inline fun <T1 : Any, T2 : Any, T3 : Any, T4 : Any, T5 : Any, T6 : Any, T7 : Any, T8 : Any, R : Any> zip(source1: Flowable<T1>, source2: Flowable<T2>,
                                                source3: Flowable<T3>, source4: Flowable<T4>,
                                                source5: Flowable<T5>, source6: Flowable<T6>,
                                                source7: Flowable<T7>, source8: Flowable<T8>,
@@ -211,7 +211,7 @@ object Flowables {
     @CheckReturnValue
     @BackpressureSupport(BackpressureKind.FULL)
     @SchedulerSupport(SchedulerSupport.NONE)
-    inline fun <T1,T2,T3,T4,T5,T6,T7,T8,T9,R> zip(source1: Flowable<T1>, source2: Flowable<T2>,
+    inline fun <T1 : Any, T2 : Any, T3 : Any, T4 : Any, T5 : Any, T6 : Any, T7 : Any, T8 : Any, T9 : Any, R : Any> zip(source1: Flowable<T1>, source2: Flowable<T2>,
                                                   source3: Flowable<T3>, source4: Flowable<T4>,
                                                   source5: Flowable<T5>, source6: Flowable<T6>,
                                                   source7: Flowable<T7>, source8: Flowable<T8>,
@@ -227,13 +227,13 @@ object Flowables {
 @CheckReturnValue
 @BackpressureSupport(BackpressureKind.PASS_THROUGH)
 @SchedulerSupport(SchedulerSupport.NONE)
-inline fun <T, U, R> Flowable<T>.withLatestFrom(other: Publisher<U>, crossinline combiner: (T, U) -> R): Flowable<R>
+inline fun <T : Any, U : Any, R : Any> Flowable<T>.withLatestFrom(other: Publisher<U>, crossinline combiner: (T, U) -> R): Flowable<R>
         = withLatestFrom(other, BiFunction<T, U, R> { t, u -> combiner.invoke(t, u)  })
 
 @CheckReturnValue
 @BackpressureSupport(BackpressureKind.PASS_THROUGH)
 @SchedulerSupport(SchedulerSupport.NONE)
-fun <T, U> Flowable<T>.withLatestFrom(other: Publisher<U>): Flowable<Pair<T, U>>
+fun <T : Any, U : Any> Flowable<T>.withLatestFrom(other: Publisher<U>): Flowable<Pair<T, U>>
         = withLatestFrom(other, BiFunction{ t, u -> Pair(t,u)  })
 
 
@@ -243,13 +243,13 @@ fun <T, U> Flowable<T>.withLatestFrom(other: Publisher<U>): Flowable<Pair<T, U>>
 @CheckReturnValue
 @BackpressureSupport(BackpressureKind.PASS_THROUGH)
 @SchedulerSupport(SchedulerSupport.NONE)
-inline fun <T, T1, T2, R> Flowable<T>.withLatestFrom(o1: Publisher<T1>, o2: Publisher<T2>, crossinline combiner: (T, T1, T2) -> R): Flowable<R>
+inline fun <T : Any, T1 : Any, T2 : Any, R : Any> Flowable<T>.withLatestFrom(o1: Publisher<T1>, o2: Publisher<T2>, crossinline combiner: (T, T1, T2) -> R): Flowable<R>
         = withLatestFrom(o1, o2, Function3 { t, t1, t2 -> combiner.invoke(t, t1, t2) })
 
 @CheckReturnValue
 @BackpressureSupport(BackpressureKind.PASS_THROUGH)
 @SchedulerSupport(SchedulerSupport.NONE)
-fun <T, T1, T2> Flowable<T>.withLatestFrom(o1: Publisher<T1>, o2: Publisher<T2>): Flowable<Triple<T,T1,T2>>
+fun <T : Any, T1 : Any, T2 : Any> Flowable<T>.withLatestFrom(o1: Publisher<T1>, o2: Publisher<T2>): Flowable<Triple<T,T1,T2>>
         = withLatestFrom(o1, o2, Function3 { t, t1, t2 -> Triple(t, t1, t2) })
 
 /**
@@ -258,7 +258,7 @@ fun <T, T1, T2> Flowable<T>.withLatestFrom(o1: Publisher<T1>, o2: Publisher<T2>)
 @CheckReturnValue
 @BackpressureSupport(BackpressureKind.PASS_THROUGH)
 @SchedulerSupport(SchedulerSupport.NONE)
-inline fun <T, T1, T2, T3, R> Flowable<T>.withLatestFrom(o1: Publisher<T1>, o2: Publisher<T2>, o3: Publisher<T3>, crossinline combiner: (T, T1, T2, T3) -> R): Flowable<R>
+inline fun <T : Any, T1 : Any, T2 : Any, T3 : Any, R : Any> Flowable<T>.withLatestFrom(o1: Publisher<T1>, o2: Publisher<T2>, o3: Publisher<T3>, crossinline combiner: (T, T1, T2, T3) -> R): Flowable<R>
         = withLatestFrom(o1, o2, o3, Function4 { t, t1, t2, t3 -> combiner.invoke(t, t1, t2, t3) })
 
 /**
@@ -267,7 +267,7 @@ inline fun <T, T1, T2, T3, R> Flowable<T>.withLatestFrom(o1: Publisher<T1>, o2: 
 @CheckReturnValue
 @BackpressureSupport(BackpressureKind.FULL)
 @SchedulerSupport(SchedulerSupport.NONE)
-inline fun <T, T1, T2, T3, T4, R> Flowable<T>.withLatestFrom(o1: Publisher<T1>, o2: Publisher<T2>, o3: Publisher<T3>, o4: Publisher<T4>, crossinline combiner: (T, T1, T2, T3, T4) -> R): Flowable<R>
+inline fun <T : Any, T1 : Any, T2 : Any, T3 : Any, T4 : Any, R : Any> Flowable<T>.withLatestFrom(o1: Publisher<T1>, o2: Publisher<T2>, o3: Publisher<T3>, o4: Publisher<T4>, crossinline combiner: (T, T1, T2, T3, T4) -> R): Flowable<R>
         = withLatestFrom(o1, o2, o3, o4, Function5 { t, t1, t2, t3, t4 -> combiner.invoke(t, t1, t2, t3, t4) })
 
 /**
@@ -276,7 +276,7 @@ inline fun <T, T1, T2, T3, T4, R> Flowable<T>.withLatestFrom(o1: Publisher<T1>, 
 @CheckReturnValue
 @BackpressureSupport(BackpressureKind.PASS_THROUGH)
 @SchedulerSupport(SchedulerSupport.NONE)
-inline fun <T, U, R> Flowable<T>.zipWith(other: Publisher<U>, crossinline zipper: (T, U) -> R): Flowable<R>
+inline fun <T : Any, U : Any, R : Any> Flowable<T>.zipWith(other: Publisher<U>, crossinline zipper: (T, U) -> R): Flowable<R>
         = zipWith(other, BiFunction { t, u -> zipper.invoke(t, u) })
 
 /**
@@ -285,5 +285,5 @@ inline fun <T, U, R> Flowable<T>.zipWith(other: Publisher<U>, crossinline zipper
 @CheckReturnValue
 @BackpressureSupport(BackpressureKind.FULL)
 @SchedulerSupport(SchedulerSupport.NONE)
-fun <T, U> Flowable<T>.zipWith(other: Publisher<U>): Flowable<Pair<T, U>>
+fun <T : Any, U : Any> Flowable<T>.zipWith(other: Publisher<U>): Flowable<Pair<T, U>>
         = zipWith(other, BiFunction { t, u -> Pair(t,u) })

--- a/src/main/kotlin/io/reactivex/rxkotlin/Maybes.kt
+++ b/src/main/kotlin/io/reactivex/rxkotlin/Maybes.kt
@@ -11,31 +11,31 @@ import io.reactivex.functions.*
 object Maybes {
     @CheckReturnValue
     @SchedulerSupport(SchedulerSupport.NONE)
-    inline fun <T, U, R> zip(s1: MaybeSource<T>, s2: MaybeSource<U>, crossinline zipper: (T, U) -> R): Maybe<R>
+    inline fun <T : Any, U : Any, R : Any> zip(s1: MaybeSource<T>, s2: MaybeSource<U>, crossinline zipper: (T, U) -> R): Maybe<R>
             = Maybe.zip(s1, s2, BiFunction { t, u -> zipper.invoke(t, u) })
 
     @CheckReturnValue
     @SchedulerSupport(SchedulerSupport.NONE)
-    fun <T, U> zip(s1: MaybeSource<T>, s2: MaybeSource<U>): Maybe<Pair<T,U>>
+    fun <T : Any, U : Any> zip(s1: MaybeSource<T>, s2: MaybeSource<U>): Maybe<Pair<T,U>>
             = Maybe.zip(s1, s2, BiFunction { t, u -> Pair(t,u) })
 
 
     @CheckReturnValue
     @SchedulerSupport(SchedulerSupport.NONE)
-    inline fun <T1, T2, T3, R>
+    inline fun <T1 : Any, T2 : Any, T3 : Any, R : Any>
             zip(s1: MaybeSource<T1>, s2: MaybeSource<T2>, s3: MaybeSource<T3>,
                 crossinline zipper: (T1, T2, T3) -> R): Maybe<R>
             = Maybe.zip(s1, s2, s3, Function3 { t1, t2, t3 -> zipper.invoke(t1, t2, t3) })
 
     @CheckReturnValue
     @SchedulerSupport(SchedulerSupport.NONE)
-    fun <T1, T2, T3>
+    fun <T1 : Any, T2 : Any, T3 : Any>
             zip(s1: MaybeSource<T1>, s2: MaybeSource<T2>, s3: MaybeSource<T3>): Maybe<Triple<T1,T2,T3>>
             = Maybe.zip(s1, s2, s3, Function3 { t1, t2, t3 -> Triple(t1,t2,t3) })
 
     @CheckReturnValue
     @SchedulerSupport(SchedulerSupport.NONE)
-    inline fun <T1, T2, T3, T4, R>
+    inline fun <T1 : Any, T2 : Any, T3 : Any, T4 : Any, R : Any>
             zip(s1: MaybeSource<T1>, s2: MaybeSource<T2>,
                 s3: MaybeSource<T3>, s4: MaybeSource<T4>,
                 crossinline zipper: (T1, T2, T3, T4) -> R): Maybe<R>
@@ -43,7 +43,7 @@ object Maybes {
 
     @CheckReturnValue
     @SchedulerSupport(SchedulerSupport.NONE)
-    inline fun <T1, T2, T3, T4, T5, R>
+    inline fun <T1 : Any, T2 : Any, T3 : Any, T4 : Any, T5 : Any, R : Any>
             zip(s1: MaybeSource<T1>, s2: MaybeSource<T2>,
                 s3: MaybeSource<T3>, s4: MaybeSource<T4>,
                 s5: MaybeSource<T5>,
@@ -52,7 +52,7 @@ object Maybes {
 
     @CheckReturnValue
     @SchedulerSupport(SchedulerSupport.NONE)
-    inline fun <T1, T2, T3, T4, T5, T6, R>
+    inline fun <T1 : Any, T2 : Any, T3 : Any, T4 : Any, T5 : Any, T6 : Any, R : Any>
             zip(s1: MaybeSource<T1>, s2: MaybeSource<T2>,
                 s3: MaybeSource<T3>, s4: MaybeSource<T4>,
                 s5: MaybeSource<T5>, s6: MaybeSource<T6>,
@@ -61,7 +61,7 @@ object Maybes {
 
     @CheckReturnValue
     @SchedulerSupport(SchedulerSupport.NONE)
-    inline fun <T1, T2, T3, T4, T5, T6, T7, R>
+    inline fun <T1 : Any, T2 : Any, T3 : Any, T4 : Any, T5 : Any, T6 : Any, T7 : Any, R : Any>
             zip(s1: MaybeSource<T1>, s2: MaybeSource<T2>,
                 s3: MaybeSource<T3>, s4: MaybeSource<T4>,
                 s5: MaybeSource<T5>, s6: MaybeSource<T6>,
@@ -71,7 +71,7 @@ object Maybes {
 
     @CheckReturnValue
     @SchedulerSupport(SchedulerSupport.NONE)
-    inline fun <T1, T2, T3, T4, T5, T6, T7, T8, R>
+    inline fun <T1 : Any, T2 : Any, T3 : Any, T4 : Any, T5 : Any, T6 : Any, T7 : Any, T8 : Any, R : Any>
             zip(s1: MaybeSource<T1>, s2: MaybeSource<T2>,
                 s3: MaybeSource<T3>, s4: MaybeSource<T4>,
                 s5: MaybeSource<T5>, s6: MaybeSource<T6>,
@@ -81,7 +81,7 @@ object Maybes {
 
     @CheckReturnValue
     @SchedulerSupport(SchedulerSupport.NONE)
-    inline fun <T1, T2, T3, T4, T5, T6, T7, T8, T9, R>
+    inline fun <T1 : Any, T2 : Any, T3 : Any, T4 : Any, T5 : Any, T6 : Any, T7 : Any, T8 : Any, T9 : Any, R : Any>
             zip(s1: MaybeSource<T1>, s2: MaybeSource<T2>,
                 s3: MaybeSource<T3>, s4: MaybeSource<T4>,
                 s5: MaybeSource<T5>, s6: MaybeSource<T6>,
@@ -96,10 +96,10 @@ object Maybes {
  */
 @CheckReturnValue
 @SchedulerSupport(SchedulerSupport.NONE)
-inline fun <T, U, R> Maybe<T>.zipWith(other: MaybeSource<U>, crossinline zipper: (T, U) -> R): Maybe<R>
+inline fun <T : Any, U : Any, R : Any> Maybe<T>.zipWith(other: MaybeSource<U>, crossinline zipper: (T, U) -> R): Maybe<R>
         = zipWith(other, BiFunction { t, u -> zipper.invoke(t, u) })
 
 @CheckReturnValue
 @SchedulerSupport(SchedulerSupport.NONE)
-fun <T, U> Maybe<T>.zipWith(other: MaybeSource<U>): Maybe<Pair<T, U>>
+fun <T : Any, U : Any> Maybe<T>.zipWith(other: MaybeSource<U>): Maybe<Pair<T, U>>
         = zipWith(other, BiFunction { t, u -> Pair(t,u) })

--- a/src/main/kotlin/io/reactivex/rxkotlin/Observables.kt
+++ b/src/main/kotlin/io/reactivex/rxkotlin/Observables.kt
@@ -15,7 +15,7 @@ object Observables {
 
     @CheckReturnValue
     @SchedulerSupport(SchedulerSupport.NONE)
-    inline fun <T1,T2,R> combineLatest(source1: Observable<T1>, source2: Observable<T2>, crossinline combineFunction: (T1, T2) -> R) =
+    inline fun <T1 : Any, T2 : Any, R : Any> combineLatest(source1: Observable<T1>, source2: Observable<T2>, crossinline combineFunction: (T1, T2) -> R) =
             Observable.combineLatest(source1, source2,
                     BiFunction<T1, T2, R> { t1, t2 -> combineFunction(t1,t2) })
 
@@ -24,13 +24,13 @@ object Observables {
      */
     @CheckReturnValue
     @SchedulerSupport(SchedulerSupport.NONE)
-    fun <T1,T2> combineLatest(source1: Observable<T1>, source2: Observable<T2>) =
+    fun <T1 : Any, T2 : Any> combineLatest(source1: Observable<T1>, source2: Observable<T2>) =
             Observable.combineLatest(source1, source2,
                     BiFunction<T1, T2, Pair<T1,T2>> { t1, t2 -> t1 to t2 })
 
     @CheckReturnValue
     @SchedulerSupport(SchedulerSupport.NONE)
-    inline fun <T1,T2,T3,R> combineLatest(source1: Observable<T1>, source2: Observable<T2>, source3: Observable<T3>, crossinline combineFunction: (T1,T2, T3) -> R) =
+    inline fun <T1 : Any, T2 : Any, T3 : Any, R : Any> combineLatest(source1: Observable<T1>, source2: Observable<T2>, source3: Observable<T3>, crossinline combineFunction: (T1,T2, T3) -> R) =
             Observable.combineLatest(source1, source2,source3,
                     Function3 { t1: T1, t2: T2, t3: T3 -> combineFunction(t1,t2, t3) })
 
@@ -39,13 +39,13 @@ object Observables {
      */
     @CheckReturnValue
     @SchedulerSupport(SchedulerSupport.NONE)
-    fun <T1,T2,T3> combineLatest(source1: Observable<T1>, source2: Observable<T2>, source3: Observable<T3>) =
+    fun <T1 : Any, T2 : Any, T3 : Any> combineLatest(source1: Observable<T1>, source2: Observable<T2>, source3: Observable<T3>) =
             Observable.combineLatest(source1, source2, source3,
                     Function3<T1, T2, T3, Triple<T1,T2,T3>> { t1, t2, t3 -> Triple(t1,t2,t3) })
 
     @CheckReturnValue
     @SchedulerSupport(SchedulerSupport.NONE)
-    inline fun <T1,T2,T3,T4,R> combineLatest(source1: Observable<T1>, source2: Observable<T2>, source3: Observable<T3>,
+    inline fun <T1 : Any, T2 : Any, T3 : Any, T4 : Any, R : Any> combineLatest(source1: Observable<T1>, source2: Observable<T2>, source3: Observable<T3>,
                                              source4: Observable<T4>, crossinline combineFunction: (T1,T2, T3, T4) -> R) =
             Observable.combineLatest(source1, source2,source3, source4,
                     Function4{ t1: T1, t2: T2, t3: T3, t4: T4 -> combineFunction(t1,t2, t3, t4) })
@@ -53,7 +53,7 @@ object Observables {
 
     @CheckReturnValue
     @SchedulerSupport(SchedulerSupport.NONE)
-    inline fun <T1,T2,T3,T4,T5,R> combineLatest(source1: Observable<T1>, source2: Observable<T2>,
+    inline fun <T1 : Any, T2 : Any, T3 : Any, T4 : Any, T5 : Any, R : Any> combineLatest(source1: Observable<T1>, source2: Observable<T2>,
                                                 source3: Observable<T3>, source4: Observable<T4>,
                                                 source5: Observable<T5>, crossinline combineFunction: (T1,T2, T3, T4, T5) -> R) =
             Observable.combineLatest(source1, source2,source3, source4, source5,
@@ -62,7 +62,7 @@ object Observables {
 
     @CheckReturnValue
     @SchedulerSupport(SchedulerSupport.NONE)
-    inline fun <T1,T2,T3,T4,T5,T6,R> combineLatest(source1: Observable<T1>, source2: Observable<T2>,
+    inline fun <T1 : Any, T2 : Any, T3 : Any, T4 : Any, T5 : Any, T6 : Any, R : Any> combineLatest(source1: Observable<T1>, source2: Observable<T2>,
                                                 source3: Observable<T3>, source4: Observable<T4>,
                                                 source5: Observable<T5>, source6: Observable<T6>, crossinline combineFunction: (T1,T2, T3, T4, T5, T6) -> R) =
             Observable.combineLatest(source1, source2,source3, source4, source5, source6,
@@ -70,7 +70,7 @@ object Observables {
 
     @CheckReturnValue
     @SchedulerSupport(SchedulerSupport.NONE)
-    inline fun <T1,T2,T3,T4,T5,T6,T7,R> combineLatest(source1: Observable<T1>, source2: Observable<T2>,
+    inline fun <T1 : Any, T2 : Any, T3 : Any, T4 : Any, T5 : Any, T6 : Any, T7 : Any, R : Any> combineLatest(source1: Observable<T1>, source2: Observable<T2>,
                                                    source3: Observable<T3>, source4: Observable<T4>,
                                                    source5: Observable<T5>, source6: Observable<T6>,
                                                       source7: Observable<T7>, crossinline combineFunction: (T1,T2, T3, T4, T5, T6, T7) -> R) =
@@ -80,7 +80,7 @@ object Observables {
 
     @CheckReturnValue
     @SchedulerSupport(SchedulerSupport.NONE)
-    inline fun <T1,T2,T3,T4,T5,T6,T7,T8,R> combineLatest(source1: Observable<T1>, source2: Observable<T2>,
+    inline fun <T1 : Any, T2 : Any, T3 : Any, T4 : Any, T5 : Any, T6 : Any, T7 : Any, T8 : Any, R : Any> combineLatest(source1: Observable<T1>, source2: Observable<T2>,
                                                       source3: Observable<T3>, source4: Observable<T4>,
                                                       source5: Observable<T5>, source6: Observable<T6>,
                                                       source7: Observable<T7>, source8: Observable<T8>,
@@ -90,7 +90,7 @@ object Observables {
 
     @CheckReturnValue
     @SchedulerSupport(SchedulerSupport.NONE)
-    inline fun <T1,T2,T3,T4,T5,T6,T7,T8,T9,R> combineLatest(source1: Observable<T1>, source2: Observable<T2>,
+    inline fun <T1 : Any, T2 : Any, T3 : Any, T4 : Any, T5 : Any, T6 : Any, T7 : Any, T8 : Any, T9 : Any, R : Any> combineLatest(source1: Observable<T1>, source2: Observable<T2>,
                                                          source3: Observable<T3>, source4: Observable<T4>,
                                                          source5: Observable<T5>, source6: Observable<T6>,
                                                          source7: Observable<T7>, source8: Observable<T8>,
@@ -101,7 +101,7 @@ object Observables {
 
     @CheckReturnValue
     @SchedulerSupport(SchedulerSupport.NONE)
-    inline fun <T1,T2,R> zip(source1: Observable<T1>, source2: Observable<T2>, crossinline combineFunction: (T1, T2) -> R) =
+    inline fun <T1 : Any, T2 : Any, R : Any> zip(source1: Observable<T1>, source2: Observable<T2>, crossinline combineFunction: (T1, T2) -> R) =
             Observable.zip(source1, source2,
                     BiFunction<T1, T2, R> { t1, t2 -> combineFunction(t1,t2) })
 
@@ -111,13 +111,13 @@ object Observables {
      */
     @CheckReturnValue
     @SchedulerSupport(SchedulerSupport.NONE)
-    fun <T1,T2> zip(source1: Observable<T1>, source2: Observable<T2>) =
+    fun <T1 : Any, T2 : Any> zip(source1: Observable<T1>, source2: Observable<T2>) =
             Observable.zip(source1, source2,
                     BiFunction<T1, T2, Pair<T1,T2>> { t1, t2 -> t1 to t2 })
 
     @CheckReturnValue
     @SchedulerSupport(SchedulerSupport.NONE)
-    inline fun <T1,T2,T3,R> zip(source1: Observable<T1>, source2: Observable<T2>, source3: Observable<T3>, crossinline combineFunction: (T1,T2, T3) -> R) =
+    inline fun <T1 : Any, T2 : Any, T3 : Any, R : Any> zip(source1: Observable<T1>, source2: Observable<T2>, source3: Observable<T3>, crossinline combineFunction: (T1,T2, T3) -> R) =
             Observable.zip(source1, source2,source3,
                     Function3 { t1: T1, t2: T2, t3: T3 -> combineFunction(t1,t2, t3) })
 
@@ -126,19 +126,19 @@ object Observables {
      */
     @CheckReturnValue
     @SchedulerSupport(SchedulerSupport.NONE)
-    fun <T1,T2,T3> zip(source1: Observable<T1>, source2: Observable<T2>, source3: Observable<T3>) =
+    fun <T1 : Any, T2 : Any, T3 : Any> zip(source1: Observable<T1>, source2: Observable<T2>, source3: Observable<T3>) =
             Observable.zip(source1, source2, source3,
                     Function3<T1, T2, T3, Triple<T1,T2,T3>> { t1, t2, t3 -> Triple(t1,t2,t3) })
 
     @CheckReturnValue
     @SchedulerSupport(SchedulerSupport.NONE)
-    inline fun <T1,T2,T3,T4,R> zip(source1: Observable<T1>, source2: Observable<T2>, source3: Observable<T3>, source4: Observable<T4>, crossinline combineFunction: (T1,T2, T3, T4) -> R) =
+    inline fun <T1 : Any, T2 : Any, T3 : Any, T4 : Any, R : Any> zip(source1: Observable<T1>, source2: Observable<T2>, source3: Observable<T3>, source4: Observable<T4>, crossinline combineFunction: (T1,T2, T3, T4) -> R) =
             Observable.zip(source1, source2,source3, source4,
                     Function4 { t1: T1, t2: T2, t3: T3, t4: T4 -> combineFunction(t1,t2, t3, t4) })
 
     @CheckReturnValue
     @SchedulerSupport(SchedulerSupport.NONE)
-    inline fun <T1,T2,T3,T4,T5,R> zip(source1: Observable<T1>, source2: Observable<T2>,
+    inline fun <T1 : Any, T2 : Any, T3 : Any, T4 : Any, T5 : Any, R : Any> zip(source1: Observable<T1>, source2: Observable<T2>,
                                       source3: Observable<T3>, source4: Observable<T4>,
                                       source5: Observable<T5>, crossinline combineFunction: (T1,T2, T3, T4, T5) -> R) =
             Observable.zip(source1, source2,source3, source4, source5,
@@ -148,7 +148,7 @@ object Observables {
 
     @CheckReturnValue
     @SchedulerSupport(SchedulerSupport.NONE)
-    inline fun <T1,T2,T3,T4,T5,T6,R> zip(source1: Observable<T1>, source2: Observable<T2>,
+    inline fun <T1 : Any, T2 : Any, T3 : Any, T4 : Any, T5 : Any, T6 : Any, R : Any> zip(source1: Observable<T1>, source2: Observable<T2>,
                                                    source3: Observable<T3>, source4: Observable<T4>,
                                                    source5: Observable<T5>, source6: Observable<T6>, crossinline combineFunction: (T1,T2, T3, T4, T5, T6) -> R) =
             Observable.zip(source1, source2,source3, source4, source5, source6,
@@ -156,7 +156,7 @@ object Observables {
 
     @CheckReturnValue
     @SchedulerSupport(SchedulerSupport.NONE)
-    inline fun <T1,T2,T3,T4,T5,T6,T7,R> zip(source1: Observable<T1>, source2: Observable<T2>,
+    inline fun <T1 : Any, T2 : Any, T3 : Any, T4 : Any, T5 : Any, T6 : Any, T7 : Any, R : Any> zip(source1: Observable<T1>, source2: Observable<T2>,
                                                       source3: Observable<T3>, source4: Observable<T4>,
                                                       source5: Observable<T5>, source6: Observable<T6>,
                                                       source7: Observable<T7>, crossinline combineFunction: (T1,T2, T3, T4, T5, T6, T7) -> R) =
@@ -166,7 +166,7 @@ object Observables {
 
     @CheckReturnValue
     @SchedulerSupport(SchedulerSupport.NONE)
-    inline fun <T1,T2,T3,T4,T5,T6,T7,T8,R> zip(source1: Observable<T1>, source2: Observable<T2>,
+    inline fun <T1 : Any, T2 : Any, T3 : Any, T4 : Any, T5 : Any, T6 : Any, T7 : Any, T8 : Any, R : Any> zip(source1: Observable<T1>, source2: Observable<T2>,
                                                          source3: Observable<T3>, source4: Observable<T4>,
                                                          source5: Observable<T5>, source6: Observable<T6>,
                                                          source7: Observable<T7>, source8: Observable<T8>,
@@ -176,7 +176,7 @@ object Observables {
 
     @CheckReturnValue
     @SchedulerSupport(SchedulerSupport.NONE)
-    inline fun <T1,T2,T3,T4,T5,T6,T7,T8,T9,R> zip(source1: Observable<T1>, source2: Observable<T2>,
+    inline fun <T1 : Any, T2 : Any, T3 : Any, T4 : Any, T5 : Any, T6 : Any, T7 : Any, T8 : Any, T9 : Any, R : Any> zip(source1: Observable<T1>, source2: Observable<T2>,
                                                             source3: Observable<T3>, source4: Observable<T4>,
                                                             source5: Observable<T5>, source6: Observable<T6>,
                                                             source7: Observable<T7>, source8: Observable<T8>,
@@ -192,7 +192,7 @@ object Observables {
  */
 @CheckReturnValue
 @SchedulerSupport(SchedulerSupport.NONE)
-inline fun <T, U, R> Observable<T>.withLatestFrom(other: ObservableSource<U>, crossinline combiner: (T, U) -> R): Observable<R>
+inline fun <T : Any, U : Any, R : Any> Observable<T>.withLatestFrom(other: ObservableSource<U>, crossinline combiner: (T, U) -> R): Observable<R>
         = withLatestFrom(other, BiFunction<T, U, R> { t, u -> combiner.invoke(t, u) })
 
 /**
@@ -200,7 +200,7 @@ inline fun <T, U, R> Observable<T>.withLatestFrom(other: ObservableSource<U>, cr
  */
 @CheckReturnValue
 @SchedulerSupport(SchedulerSupport.NONE)
-fun <T, U> Observable<T>.withLatestFrom(other: ObservableSource<U>): Observable<Pair<T,U>>
+fun <T : Any, U : Any> Observable<T>.withLatestFrom(other: ObservableSource<U>): Observable<Pair<T,U>>
         = withLatestFrom(other, BiFunction{ t, u -> Pair(t,u) })
 
 /**
@@ -208,12 +208,12 @@ fun <T, U> Observable<T>.withLatestFrom(other: ObservableSource<U>): Observable<
  */
 @CheckReturnValue
 @SchedulerSupport(SchedulerSupport.NONE)
-inline fun <T, T1, T2, R> Observable<T>.withLatestFrom(o1: ObservableSource<T1>, o2: ObservableSource<T2>, crossinline combiner: (T, T1, T2) -> R): Observable<R>
+inline fun <T : Any, T1 : Any, T2 : Any, R : Any> Observable<T>.withLatestFrom(o1: ObservableSource<T1>, o2: ObservableSource<T2>, crossinline combiner: (T, T1, T2) -> R): Observable<R>
         = withLatestFrom(o1, o2, Function3<T, T1, T2, R> { t, t1, t2 -> combiner.invoke(t, t1, t2) })
 
 @CheckReturnValue
 @SchedulerSupport(SchedulerSupport.NONE)
-fun <T, T1, T2> Observable<T>.withLatestFrom(o1: ObservableSource<T1>, o2: ObservableSource<T2>): Observable<Triple<T,T1,T2>>
+fun <T : Any, T1 : Any, T2 : Any> Observable<T>.withLatestFrom(o1: ObservableSource<T1>, o2: ObservableSource<T2>): Observable<Triple<T,T1,T2>>
         = withLatestFrom(o1, o2, Function3 { t, t1, t2 -> Triple(t, t1, t2) })
 
 /**
@@ -221,7 +221,7 @@ fun <T, T1, T2> Observable<T>.withLatestFrom(o1: ObservableSource<T1>, o2: Obser
  */
 @CheckReturnValue
 @SchedulerSupport(SchedulerSupport.NONE)
-inline fun <T, T1, T2, T3, R> Observable<T>.withLatestFrom(o1: ObservableSource<T1>, o2: ObservableSource<T2>, o3: ObservableSource<T3>, crossinline combiner: (T, T1, T2, T3) -> R): Observable<R>
+inline fun <T : Any, T1 : Any, T2 : Any, T3 : Any, R : Any> Observable<T>.withLatestFrom(o1: ObservableSource<T1>, o2: ObservableSource<T2>, o3: ObservableSource<T3>, crossinline combiner: (T, T1, T2, T3) -> R): Observable<R>
         = withLatestFrom(o1, o2, o3, Function4<T, T1, T2, T3, R> { t, t1, t2, t3 -> combiner.invoke(t, t1, t2, t3) })
 
 /**
@@ -229,7 +229,7 @@ inline fun <T, T1, T2, T3, R> Observable<T>.withLatestFrom(o1: ObservableSource<
  */
 @CheckReturnValue
 @SchedulerSupport(SchedulerSupport.NONE)
-inline fun <T, T1, T2, T3, T4, R> Observable<T>.withLatestFrom(o1: ObservableSource<T1>, o2: ObservableSource<T2>, o3: ObservableSource<T3>, o4: ObservableSource<T4>, crossinline combiner: (T, T1, T2, T3, T4) -> R): Observable<R>
+inline fun <T : Any, T1 : Any, T2 : Any, T3 : Any, T4 : Any, R : Any> Observable<T>.withLatestFrom(o1: ObservableSource<T1>, o2: ObservableSource<T2>, o3: ObservableSource<T3>, o4: ObservableSource<T4>, crossinline combiner: (T, T1, T2, T3, T4) -> R): Observable<R>
         = withLatestFrom(o1, o2, o3, o4, Function5<T, T1, T2, T3, T4, R> { t, t1, t2, t3, t4 -> combiner.invoke(t, t1, t2, t3, t4) })
 
 /**
@@ -237,7 +237,7 @@ inline fun <T, T1, T2, T3, T4, R> Observable<T>.withLatestFrom(o1: ObservableSou
  */
 @CheckReturnValue
 @SchedulerSupport(SchedulerSupport.NONE)
-inline fun <T, U, R> Observable<T>.zipWith(other: ObservableSource<U>, crossinline zipper: (T, U) -> R): Observable<R>
+inline fun <T : Any, U : Any, R : Any> Observable<T>.zipWith(other: ObservableSource<U>, crossinline zipper: (T, U) -> R): Observable<R>
         = zipWith(other, BiFunction { t, u -> zipper.invoke(t, u) })
 
 /**
@@ -245,5 +245,5 @@ inline fun <T, U, R> Observable<T>.zipWith(other: ObservableSource<U>, crossinli
  */
 @CheckReturnValue
 @SchedulerSupport(SchedulerSupport.NONE)
-fun <T, U> Observable<T>.zipWith(other: ObservableSource<U>): Observable<Pair<T,U>>
+fun <T : Any, U : Any> Observable<T>.zipWith(other: ObservableSource<U>): Observable<Pair<T,U>>
         = zipWith(other, BiFunction { t, u -> Pair(t,u) })

--- a/src/main/kotlin/io/reactivex/rxkotlin/Singles.kt
+++ b/src/main/kotlin/io/reactivex/rxkotlin/Singles.kt
@@ -10,31 +10,31 @@ import io.reactivex.functions.*
 object Singles {
     @CheckReturnValue
     @SchedulerSupport(SchedulerSupport.NONE)
-    inline fun <T, U, R> zip(s1: SingleSource<T>, s2: SingleSource<U>, crossinline zipper: (T, U) -> R): Single<R>
+    inline fun <T : Any, U : Any, R : Any> zip(s1: SingleSource<T>, s2: SingleSource<U>, crossinline zipper: (T, U) -> R): Single<R>
             = Single.zip(s1, s2, BiFunction { t, u -> zipper.invoke(t, u) })
 
     @CheckReturnValue
     @SchedulerSupport(SchedulerSupport.NONE)
-    fun <T, U> zip(s1: SingleSource<T>, s2: SingleSource<U>): Single<Pair<T,U>>
+    fun <T : Any, U : Any> zip(s1: SingleSource<T>, s2: SingleSource<U>): Single<Pair<T,U>>
             = Single.zip(s1, s2, BiFunction { t, u -> Pair(t,u) })
 
 
     @CheckReturnValue
     @SchedulerSupport(SchedulerSupport.NONE)
-    inline fun <T1, T2, T3, R>
+    inline fun <T1 : Any, T2 : Any, T3 : Any, R : Any>
             zip(s1: SingleSource<T1>, s2: SingleSource<T2>, s3: SingleSource<T3>,
                 crossinline zipper: (T1, T2, T3) -> R): Single<R>
             = Single.zip(s1, s2, s3, Function3 { t1, t2, t3 -> zipper.invoke(t1, t2, t3) })
 
     @CheckReturnValue
     @SchedulerSupport(SchedulerSupport.NONE)
-    fun <T1, T2, T3>
+    fun <T1 : Any, T2 : Any, T3 : Any>
             zip(s1: SingleSource<T1>, s2: SingleSource<T2>, s3: SingleSource<T3>): Single<Triple<T1,T2,T3>>
             = Single.zip(s1, s2, s3, Function3 { t1, t2, t3 -> Triple(t1,t2,t3) })
 
     @CheckReturnValue
     @SchedulerSupport(SchedulerSupport.NONE)
-    inline fun <T1, T2, T3, T4, R>
+    inline fun <T1 : Any, T2 : Any, T3 : Any, T4 : Any, R : Any>
             zip(s1: SingleSource<T1>, s2: SingleSource<T2>,
                 s3: SingleSource<T3>, s4: SingleSource<T4>,
                 crossinline zipper: (T1, T2, T3, T4) -> R): Single<R>
@@ -42,7 +42,7 @@ object Singles {
 
     @CheckReturnValue
     @SchedulerSupport(SchedulerSupport.NONE)
-    inline fun <T1, T2, T3, T4, T5, R>
+    inline fun <T1 : Any, T2 : Any, T3 : Any, T4 : Any, T5 : Any, R : Any>
             zip(s1: SingleSource<T1>, s2: SingleSource<T2>,
                 s3: SingleSource<T3>, s4: SingleSource<T4>,
                 s5: SingleSource<T5>,
@@ -51,7 +51,7 @@ object Singles {
 
     @CheckReturnValue
     @SchedulerSupport(SchedulerSupport.NONE)
-    inline fun <T1, T2, T3, T4, T5, T6, R>
+    inline fun <T1 : Any, T2 : Any, T3 : Any, T4 : Any, T5 : Any, T6 : Any, R : Any>
             zip(s1: SingleSource<T1>, s2: SingleSource<T2>,
                 s3: SingleSource<T3>, s4: SingleSource<T4>,
                 s5: SingleSource<T5>, s6: SingleSource<T6>,
@@ -60,7 +60,7 @@ object Singles {
 
     @CheckReturnValue
     @SchedulerSupport(SchedulerSupport.NONE)
-    inline fun <T1, T2, T3, T4, T5, T6, T7, R>
+    inline fun <T1 : Any, T2 : Any, T3 : Any, T4 : Any, T5 : Any, T6 : Any, T7 : Any, R : Any>
             zip(s1: SingleSource<T1>, s2: SingleSource<T2>,
                 s3: SingleSource<T3>, s4: SingleSource<T4>,
                 s5: SingleSource<T5>, s6: SingleSource<T6>,
@@ -70,7 +70,7 @@ object Singles {
 
     @CheckReturnValue
     @SchedulerSupport(SchedulerSupport.NONE)
-    inline fun <T1, T2, T3, T4, T5, T6, T7, T8, R>
+    inline fun <T1 : Any, T2 : Any, T3 : Any, T4 : Any, T5 : Any, T6 : Any, T7 : Any, T8 : Any, R : Any>
             zip(s1: SingleSource<T1>, s2: SingleSource<T2>,
                 s3: SingleSource<T3>, s4: SingleSource<T4>,
                 s5: SingleSource<T5>, s6: SingleSource<T6>,
@@ -80,7 +80,7 @@ object Singles {
 
     @CheckReturnValue
     @SchedulerSupport(SchedulerSupport.NONE)
-    inline fun <T1, T2, T3, T4, T5, T6, T7, T8, T9, R>
+    inline fun <T1 : Any, T2 : Any, T3 : Any, T4 : Any, T5 : Any, T6 : Any, T7 : Any, T8 : Any, T9 : Any, R : Any>
             zip(s1: SingleSource<T1>, s2: SingleSource<T2>,
                 s3: SingleSource<T3>, s4: SingleSource<T4>,
                 s5: SingleSource<T5>, s6: SingleSource<T6>,
@@ -92,11 +92,11 @@ object Singles {
 
 @CheckReturnValue
 @SchedulerSupport(SchedulerSupport.NONE)
-inline fun <T, U, R> Single<T>.zipWith(other: SingleSource<U>, crossinline zipper: (T, U) -> R): Single<R>
+inline fun <T : Any, U : Any, R : Any> Single<T>.zipWith(other: SingleSource<U>, crossinline zipper: (T, U) -> R): Single<R>
         = zipWith(other, BiFunction { t, u -> zipper.invoke(t, u) })
 
 
 @CheckReturnValue
 @SchedulerSupport(SchedulerSupport.NONE)
-fun <T, U> Single<T>.zipWith(other: SingleSource<U>): Single<Pair<T,U>>
+fun <T : Any, U : Any> Single<T>.zipWith(other: SingleSource<U>): Single<Pair<T,U>>
         = zipWith(other, BiFunction { t, u -> Pair(t,u) })


### PR DESCRIPTION
1) Kotlin is [Null-safe](https://kotlinlang.org/docs/reference/null-safety.html). That means that each possible NPE should be found during compilation, not in runtime
2) RxJava2 [doesn't allow nulls](https://github.com/ReactiveX/RxJava/wiki/What's-different-in-2.0#nulls)
3) In order to make generics in Kotlin to allow only non-null types it is required to state it explicitly (like `<T : Any>`)
4) Each file maybe.kt, flowable.kt etc. already has this

This PR is about patching observables.kt, singles.kt etc. to not allow nullable types.

Thanks.