### PR TITLE
Update gradle directives from compile to implementation

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -15,11 +15,11 @@ apply plugin: 'kotlin'
 apply plugin: 'java'
 
 dependencies {
-    compile 'io.reactivex.rxjava2:rxjava:2.2.0'
-    compile "org.jetbrains.kotlin:kotlin-stdlib:$kotlin_version"
-    testCompile 'org.funktionale:funktionale-partials:1.0.0-final'
-    testCompile 'junit:junit:4.12'
-    testCompile 'org.mockito:mockito-core:1.10.19'
+    implementation 'io.reactivex.rxjava2:rxjava:2.2.0'
+    implementation "org.jetbrains.kotlin:kotlin-stdlib:$kotlin_version"
+    testImplementation 'org.funktionale:funktionale-partials:1.0.0-final'
+    testImplementation 'junit:junit:4.12'
+    testImplementation 'org.mockito:mockito-core:1.10.19'
     examplesCompile 'com.squareup.retrofit2:retrofit:2.3.0'
     examplesCompile 'com.squareup.retrofit2:adapter-rxjava2:2.3.0'
     examplesCompile 'com.squareup.retrofit2:converter-moshi:2.3.0'

--- a/build.gradle
+++ b/build.gradle
@@ -26,7 +26,7 @@ dependencies {
 }
 
 task wrapper(type: Wrapper) {
-    gradleVersion = '2.14'
+    gradleVersion = '4.2'
 }
 
 // support for snapshot/final releases with the various branches RxJava uses

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-2.14-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-4.2-bin.zip


### PR DESCRIPTION
Gradle has now released Gradle 5.0. In line with this is the deprecation of `compile` and other related directives. I think it's time for us to remove the directive for this project with respect to the users (projects) of this dependency who will upgrade to Gradle 5.0.
Ref: #204 