### PR TITLE
Improve test suite for single and Singles

### DIFF
--- a/src/test/kotlin/io/reactivex/rxkotlin/SingleTest.kt
+++ b/src/test/kotlin/io/reactivex/rxkotlin/SingleTest.kt
@@ -1,8 +1,11 @@
 package io.reactivex.rxkotlin
 
+import io.reactivex.Flowable
+import io.reactivex.Observable
 import io.reactivex.Single
 import io.reactivex.observers.LambdaConsumerIntrospection
 import org.junit.Assert
+import org.junit.Assert.assertEquals
 import org.junit.Test
 import org.mockito.Mockito
 import org.mockito.Mockito.verify
@@ -47,7 +50,43 @@ class SingleTest : KotlinTests() {
                 .concatAll()
                 .toList()
                 .subscribe { result ->
-                    Assert.assertEquals((0 until 10).toList(), result)
+                    assertEquals((0 until 10).toList(), result)
                 }
+    }
+
+    @Test fun testMergeAllSinglesForObservable() {
+        val initialData = Observable.just(
+            Single.just(1),
+            Single.just(2),
+            Single.just(3),
+            Single.just(4)
+        )
+
+        val expected = mutableListOf<Int>().let { list ->
+            initialData.flatMapSingle { it }.blockingIterable().forEach { list.add(it) }
+        }
+        val actual = mutableListOf<Int>().let {list ->
+            initialData.mergeAllSingles().blockingIterable().forEach { list.add(it) }
+        }
+
+        assertEquals(expected, actual)
+    }
+
+    @Test fun testMergeAllSinglesForFlowable() {
+        val initialData = Flowable.just(
+            Single.just(1),
+            Single.just(2),
+            Single.just(3),
+            Single.just(4)
+        )
+
+        val expected = mutableListOf<Int>().let { list ->
+            initialData.flatMapSingle { it }.blockingIterable().forEach { list.add(it) }
+        }
+        val actual = mutableListOf<Int>().let {list ->
+            initialData.mergeAllSingles().blockingIterable().forEach { list.add(it) }
+        }
+
+        assertEquals(expected, actual)
     }
 }

--- a/src/test/kotlin/io/reactivex/rxkotlin/SinglesTest.kt
+++ b/src/test/kotlin/io/reactivex/rxkotlin/SinglesTest.kt
@@ -2,6 +2,8 @@ package io.reactivex.rxkotlin
 
 import io.reactivex.Single
 import io.reactivex.SingleSource
+import io.reactivex.functions.BiFunction
+import org.junit.Assert.assertEquals
 import org.junit.Test
 
 class SinglesTest : KotlinTests() {
@@ -106,6 +108,26 @@ class SinglesTest : KotlinTests() {
                     assert(eight == 8, { -> "Should equal eight"})
                     assert(nine == 9, { -> "Should equal nine"})
                 }).blockingGet()
+    }
+
+    @Test fun zipWith() {
+        val first = Single.just(1)
+        val second = Single.just(2)
+
+        val expected = first.zipWith(second, BiFunction<Int, Int, Pair<Int, Int>> { f, s -> Pair(f, s)}).blockingGet()
+        val actual = first.zipWith(second).blockingGet()
+
+        assertEquals(expected, actual)
+    }
+
+    @Test fun zipWithExplicitZipper() {
+        val first = Single.just(1)
+        val second = Single.just(2)
+
+        val expected = first.zipWith(second, BiFunction<Int, Int, Pair<Int, Int>> { f, s -> Pair(s, f)}).blockingGet()
+        val actual = first.zipWith(second) { f, s -> Pair(s, f) }.blockingGet()
+
+        assertEquals(expected, actual)
     }
 }
 

--- a/src/test/kotlin/io/reactivex/rxkotlin/SinglesTest.kt
+++ b/src/test/kotlin/io/reactivex/rxkotlin/SinglesTest.kt
@@ -1,113 +1,182 @@
 package io.reactivex.rxkotlin
 
 import io.reactivex.Single
-import io.reactivex.SingleSource
 import io.reactivex.functions.BiFunction
+import io.reactivex.functions.Function3
+import io.reactivex.functions.Function4
+import io.reactivex.functions.Function5
+import io.reactivex.functions.Function6
+import io.reactivex.functions.Function7
+import io.reactivex.functions.Function8
+import io.reactivex.functions.Function9
 import org.junit.Assert.assertEquals
 import org.junit.Test
 
 class SinglesTest : KotlinTests() {
 
-    @Test fun testParameterOrder() {
-        Singles.zip(
-                SingleSourceInt(1), SingleSourceInt(2),
-                {one, two ->
-                    assert(one == 1, { -> "Should equal one"})
-                    assert(two == 2, { -> "Should equal two"})
-                }).blockingGet()
+    @Test fun zipTwoSinglesWithExplicitZipper() {
+        val first = Single.just(1)
+        val second = Single.just(2)
 
-        Singles.zip(
-                SingleSourceInt(1), SingleSourceInt(2),
-                SingleSourceInt(3),
-                {one, two, three ->
-                    assert(one == 1, { -> "Should equal one"})
-                    assert(two == 2, { -> "Should equal two"})
-                    assert(three == 3, { -> "Should equal three"})
-                }).blockingGet()
+        val expected = Single.zip(first, second, BiFunction<Int, Int, Pair<Int, Int>> { f, s -> Pair(s, f)}).blockingGet()
+        val actual = Singles.zip(first, second) { f, s -> Pair(s, f) }.blockingGet()
 
-        Singles.zip(
-                SingleSourceInt(1), SingleSourceInt(2),
-                SingleSourceInt(3), SingleSourceInt(4),
-                {one, two, three, four ->
-                    assert(one == 1, { -> "Should equal one"})
-                    assert(two == 2, { -> "Should equal two"})
-                    assert(three == 3, { -> "Should equal three"})
-                    assert(four == 4, { -> "Should equal four"})
-                }).blockingGet()
+        assertEquals(expected, actual)
+    }
 
-        Singles.zip(
-                SingleSourceInt(1), SingleSourceInt(2),
-                SingleSourceInt(3), SingleSourceInt(4),
-                SingleSourceInt(5),
-                {one, two, three, four, five ->
-                    assert(one == 1, { -> "Should equal one"})
-                    assert(two == 2, { -> "Should equal two"})
-                    assert(three == 3, { -> "Should equal three"})
-                    assert(four == 4, { -> "Should equal four"})
-                    assert(five == 5, { -> "Should equal five"})
-                }).blockingGet()
+    @Test fun zipTwoSinglesWithNoExplicitZipper() {
+        val first = Single.just(1)
+        val second = Single.just(2)
 
-        Singles.zip(
-                SingleSourceInt(1), SingleSourceInt(2),
-                SingleSourceInt(3), SingleSourceInt(4),
-                SingleSourceInt(5), SingleSourceInt(6),
-                {one, two, three, four, five, six ->
-                    assert(one == 1, { -> "Should equal one"})
-                    assert(two == 2, { -> "Should equal two"})
-                    assert(three == 3, { -> "Should equal three"})
-                    assert(four == 4, { -> "Should equal four"})
-                    assert(five == 5, { -> "Should equal five"})
-                    assert(six == 6, { -> "Should equal six"})
-                }).blockingGet()
+        val expected = Single.zip(first, second, BiFunction<Int, Int, Pair<Int, Int>> { f, s -> Pair(f, s)}).blockingGet()
+        val actual = Singles.zip(first, second).blockingGet()
 
-        Singles.zip(
-                SingleSourceInt(1), SingleSourceInt(2),
-                SingleSourceInt(3), SingleSourceInt(4),
-                SingleSourceInt(5), SingleSourceInt(6),
-                SingleSourceInt(7),
-                {one, two, three, four, five, six, seven ->
-                    assert(one == 1, { -> "Should equal one"})
-                    assert(two == 2, { -> "Should equal two"})
-                    assert(three == 3, { -> "Should equal three"})
-                    assert(four == 4, { -> "Should equal four"})
-                    assert(five == 5, { -> "Should equal five"})
-                    assert(six == 6, { -> "Should equal six"})
-                    assert(seven == 7, { -> "Should equal seven"})
-                }).blockingGet()
+        assertEquals(expected, actual)
+    }
 
-        Singles.zip(
-                SingleSourceInt(1), SingleSourceInt(2),
-                SingleSourceInt(3), SingleSourceInt(4),
-                SingleSourceInt(5), SingleSourceInt(6),
-                SingleSourceInt(7), SingleSourceInt(8),
-                {one, two, three, four, five, six, seven, eight ->
-                    assert(one == 1, { -> "Should equal one"})
-                    assert(two == 2, { -> "Should equal two"})
-                    assert(three == 3, { -> "Should equal three"})
-                    assert(four == 4, { -> "Should equal four"})
-                    assert(five == 5, { -> "Should equal five"})
-                    assert(six == 6, { -> "Should equal six"})
-                    assert(seven == 7, { -> "Should equal seven"})
-                    assert(eight == 8, { -> "Should equal eight"})
-                }).blockingGet()
+    @Test fun zipThreeSinglesWithExplicitZipper() {
+        val first = Single.just(1)
+        val second = Single.just(2)
+        val third = Single.just(3)
 
-        Singles.zip(
-                SingleSourceInt(1), SingleSourceInt(2),
-                SingleSourceInt(3), SingleSourceInt(4),
-                SingleSourceInt(5), SingleSourceInt(6),
-                SingleSourceInt(7), SingleSourceInt(8),
-                SingleSourceInt(9),
-                {one, two, three, four, five, six, seven, eight, nine ->
-                    assert(one == 1, { -> "Should equal one"})
-                    assert(two == 2, { -> "Should equal two"})
-                    assert(three == 3, { -> "Should equal three"})
-                    assert(four == 4, { -> "Should equal four"})
-                    assert(five == 5, { -> "Should equal five"})
-                    assert(six == 6, { -> "Should equal six"})
-                    assert(seven == 7, { -> "Should equal seven"})
-                    assert(eight == 8, { -> "Should equal eight"})
-                    assert(nine == 9, { -> "Should equal nine"})
-                }).blockingGet()
+        val expected = Single.zip(first, second, third, Function3<Int, Int, Int, Triple<Int, Int, Int>> { f, s, t -> Triple(t, s, f)}).blockingGet()
+        val actual = Singles.zip(first, second, third) { f, s, t -> Triple(t, s, f) }.blockingGet()
+
+        assertEquals(expected, actual)
+    }
+
+    @Test fun zipThreeSinglesWithNoExplicitZipper() {
+        val first = Single.just(1)
+        val second = Single.just(2)
+        val third = Single.just(3)
+
+        val expected = Single.zip(first, second, third, Function3<Int, Int, Int, Triple<Int, Int, Int>> { f, s, t -> Triple(f, s, t)}).blockingGet()
+        val actual = Singles.zip(first, second, third).blockingGet()
+
+        assertEquals(expected, actual)
+    }
+
+    @Test fun zipFourSingles() {
+        val first = Single.just(1)
+        val second = Single.just(2)
+        val third = Single.just(3)
+        val fourth = Single.just(4)
+
+        val zipperFunction = Function4<Int, Int, Int, Int, String> { t1, t2, t3, t4 ->
+            "$t1$t2$t3$t4"
+        }
+
+        val expected = Single.zip(first, second, third, fourth, zipperFunction).blockingGet()
+        val actual = Singles.zip(first, second, third, fourth) { t1, t2, t3, t4 ->
+            "$t1$t2$t3$t4"
+        }.blockingGet()
+
+        assertEquals(expected, actual)
+    }
+
+    @Test fun zipFiveSingles() {
+        val first = Single.just(1)
+        val second = Single.just(2)
+        val third = Single.just(3)
+        val fourth = Single.just(2)
+        val fifth = Single.just(3)
+
+        val zipperFunction = Function5<Int, Int, Int, Int, Int, String> { t1, t2, t3, t4, t5 ->
+            "$t1$t2$t3$t4$t5"
+        }
+
+        val expected = Single.zip(first, second, third, fourth, fifth, zipperFunction).blockingGet()
+        val actual = Singles.zip(first, second, third, fourth, fifth) { t1, t2, t3, t4, t5 ->
+            "$t1$t2$t3$t4$t5"
+        }.blockingGet()
+
+        assertEquals(expected, actual)
+    }
+
+    @Test fun zipSixSingles() {
+        val first = Single.just(1)
+        val second = Single.just(2)
+        val third = Single.just(3)
+        val fourth = Single.just(4)
+        val fifth = Single.just(5)
+        val sixth = Single.just(6)
+
+        val zipperFunction = Function6<Int, Int, Int, Int, Int, Int, String> { t1, t2, t3, t4, t5, t6 ->
+            "$t1$t2$t3$t4$t5$t6"
+        }
+
+        val expected = Single.zip(first, second, third, fourth, fifth, sixth, zipperFunction).blockingGet()
+        val actual = Singles.zip(first, second, third, fourth, fifth, sixth) { t1, t2, t3, t4, t5, t6 ->
+            "$t1$t2$t3$t4$t5$t6"
+        }.blockingGet()
+
+        assertEquals(expected, actual)
+    }
+
+    @Test fun zipSevenSingles() {
+        val first = Single.just(1)
+        val second = Single.just(2)
+        val third = Single.just(3)
+        val fourth = Single.just(4)
+        val fifth = Single.just(5)
+        val sixth = Single.just(6)
+        val seventh = Single.just(7)
+
+        val zipperFunction = Function7<Int, Int, Int, Int, Int, Int, Int, String> { t1, t2, t3, t4, t5, t6, t7 ->
+            "$t1$t2$t3$t4$t5$t6$t7"
+        }
+
+        val expected = Single.zip(first, second, third, fourth, fifth, sixth, seventh, zipperFunction).blockingGet()
+        val actual = Singles.zip(first, second, third, fourth, fifth, sixth, seventh) { t1, t2, t3, t4, t5, t6, t7 ->
+            "$t1$t2$t3$t4$t5$t6$t7"
+        }.blockingGet()
+
+        assertEquals(expected, actual)
+    }
+
+    @Test fun zipEightSingles() {
+        val first = Single.just(1)
+        val second = Single.just(2)
+        val third = Single.just(3)
+        val fourth = Single.just(4)
+        val fifth = Single.just(5)
+        val sixth = Single.just(6)
+        val seventh = Single.just(7)
+        val eighth = Single.just(8)
+
+        val zipperFunction = Function8<Int, Int, Int, Int, Int, Int, Int, Int, String> { t1, t2, t3, t4, t5, t6, t7, t8 ->
+            "$t1$t2$t3$t4$t5$t6$t7$t8"
+        }
+
+        val expected = Single.zip(first, second, third, fourth, fifth, sixth, seventh, eighth, zipperFunction).blockingGet()
+        val actual = Singles.zip(first, second, third, fourth, fifth, sixth, seventh, eighth) { t1, t2, t3, t4, t5, t6, t7, t8 ->
+            "$t1$t2$t3$t4$t5$t6$t7$t8"
+        }.blockingGet()
+
+        assertEquals(expected, actual)
+    }
+
+    @Test fun zipNineSingles() {
+        val first = Single.just(1)
+        val second = Single.just(2)
+        val third = Single.just(3)
+        val fourth = Single.just(4)
+        val fifth = Single.just(5)
+        val sixth = Single.just(6)
+        val seventh = Single.just(7)
+        val eighth = Single.just(8)
+        val ninth = Single.just(9)
+
+        val zipperFunction = Function9<Int, Int, Int, Int, Int, Int, Int, Int, Int, String> { t1, t2, t3, t4, t5, t6, t7, t8, t9 ->
+            "$t1$t2$t3$t4$t5$t6$t7$t8$t9"
+        }
+
+        val expected = Single.zip(first, second, third, fourth, fifth, sixth, seventh, eighth, ninth, zipperFunction).blockingGet()
+        val actual = Singles.zip(first, second, third, fourth, fifth, sixth, seventh, eighth, ninth) { t1, t2, t3, t4, t5, t6, t7, t8, t9 ->
+            "$t1$t2$t3$t4$t5$t6$t7$t8$t9"
+        }.blockingGet()
+
+        assertEquals(expected, actual)
     }
 
     @Test fun zipWith() {
@@ -129,8 +198,4 @@ class SinglesTest : KotlinTests() {
 
         assertEquals(expected, actual)
     }
-}
-
-fun SingleSourceInt(i: Int): SingleSource<Int> {
-    return Single.create({ s -> s.onSuccess(i)})
 }


### PR DESCRIPTION
The previous test suite for extension functions of single and the Singles singleton was leaving a lot to be desired. This PR introduces tests that check that any extension function or method behave the same as the RxJava equivalent.