### PR TITLE
Add extension method toSingle

### DIFF
--- a/src/main/kotlin/io/reactivex/rxkotlin/Singles.kt
+++ b/src/main/kotlin/io/reactivex/rxkotlin/Singles.kt
@@ -123,3 +123,7 @@ inline fun <T : Any, U : Any, R : Any> Single<T>.zipWith(
 @SchedulerSupport(SchedulerSupport.NONE)
 fun <T : Any, U : Any> Single<T>.zipWith(other: SingleSource<U>): Single<Pair<T, U>> =
         zipWith(other, BiFunction { t, u -> Pair(t, u) })
+
+@CheckReturnValue
+@SchedulerSupport(SchedulerSupport.NONE)
+fun <T : Any> T.toSingle(): Single<T> = Single.just(this)

--- a/src/test/kotlin/io/reactivex/rxkotlin/SingleTest.kt
+++ b/src/test/kotlin/io/reactivex/rxkotlin/SingleTest.kt
@@ -8,7 +8,8 @@ import org.mockito.Mockito
 import org.mockito.Mockito.verify
 
 class SingleTest : KotlinTests() {
-    @Test fun testCreate() {
+    @Test
+    fun testCreate() {
         Single.create<String> { s ->
             s.onSuccess("Hello World!")
         }.subscribe { result ->
@@ -41,7 +42,8 @@ class SingleTest : KotlinTests() {
         Assert.assertTrue(disposable.hasCustomOnError())
     }
 
-    @Test fun testConcatAll() {
+    @Test
+    fun testConcatAll() {
         (0 until 10)
                 .map { Single.just(it) }
                 .concatAll()
@@ -49,5 +51,16 @@ class SingleTest : KotlinTests() {
                 .subscribe { result ->
                     Assert.assertEquals((0 until 10).toList(), result)
                 }
+    }
+
+    @Test
+    fun testSingleJust() {
+        val data = "Beta"
+
+        data.toSingle()
+                .subscribeBy(onSuccess = a::received)
+
+        verify(a, Mockito.times(1))
+                .received(data)
     }
 }


### PR DESCRIPTION
1. Add extension method `toSingle` for create a Single from object. Like an Observable from Collections.
2. Small code reformation.
