### PR TITLE
Add extension method toSingle

### DIFF
--- a/src/main/kotlin/io/reactivex/rxjava3/kotlin/Singles.kt
+++ b/src/main/kotlin/io/reactivex/rxjava3/kotlin/Singles.kt
@@ -123,3 +123,7 @@ inline fun <T : Any, U : Any, R : Any> Single<T>.zipWith(
 @SchedulerSupport(SchedulerSupport.NONE)
 fun <T : Any, U : Any> Single<T>.zipWith(other: SingleSource<U>): Single<Pair<T, U>> =
         zipWith(other, BiFunction { t, u -> Pair(t, u) })
+
+@CheckReturnValue
+@SchedulerSupport(SchedulerSupport.NONE)
+fun <T : Any> T.toSingle(): Single<T> = Single.just(this)

--- a/src/test/kotlin/io/reactivex/rxjava3/kotlin/SingleTest.kt
+++ b/src/test/kotlin/io/reactivex/rxjava3/kotlin/SingleTest.kt
@@ -8,7 +8,9 @@ import org.mockito.Mockito
 import org.mockito.Mockito.verify
 
 class SingleTest : KotlinTests() {
-    @Test fun testCreate() {
+
+    @Test
+    fun testCreate() {
         Single.create<String> { s ->
             s.onSuccess("Hello World!")
         }.subscribe { result ->
@@ -45,13 +47,14 @@ class SingleTest : KotlinTests() {
     fun testBlockingSubscribeBy() {
         Single.just("Alpha")
                 .blockingSubscribeBy {
-                   a.received(it)
+                    a.received(it)
                 }
         verify(a, Mockito.times(1))
                 .received("Alpha")
     }
 
-    @Test fun testConcatAll() {
+    @Test
+    fun testConcatAll() {
         (0 until 10)
                 .map { Single.just(it) }
                 .concatAll()
@@ -59,5 +62,16 @@ class SingleTest : KotlinTests() {
                 .subscribe { result ->
                     Assert.assertEquals((0 until 10).toList(), result)
                 }
+    }
+
+    @Test
+    fun testSingleJust() {
+        val data = "Beta"
+
+        data.toSingle()
+                .subscribeBy(onSuccess = a::received)
+
+        verify(a, Mockito.times(1))
+                .received(data)
     }
 }


### PR DESCRIPTION
The PR is a copy of #230, but based on brach 3.x 

- Add extension method `toSingle` for create a Single from object. Like an Observable from Collections.
- Small code reformation.
