### PR TITLE
Handle new type inference algorithm

### DIFF
--- a/README.md
+++ b/README.md
@@ -229,7 +229,10 @@ Learn more about building this project with JitPack [here](https://jitpack.io/#R
 
 
 
-## SAM Helpers
+## SAM Helpers (made obsolete since Kotlin 1.4)
+
+_These methods have been made obsolete with new type inference algorithm in Kotlin 1.4.
+They will be removed in some future RxKotlin version._
 
 To help cope with the [SAM ambiguity issue](https://youtrack.jetbrains.com/issue/KT-14984) when using RxJava with Kotlin, there are a number of helper factories and extension functions to workaround the affected operators. 
 

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -11,7 +11,7 @@ buildscript {
 
 plugins {
     id("java-library")
-    kotlin("jvm") version "1.3.40"
+    kotlin("jvm") version "1.4.0"
     id("org.jetbrains.dokka") version "0.9.18"
     id("maven-publish")
     id("com.jfrog.bintray") version "1.8.4"

--- a/src/main/kotlin/io/reactivex/rxjava3/kotlin/Flowables.kt
+++ b/src/main/kotlin/io/reactivex/rxjava3/kotlin/Flowables.kt
@@ -15,6 +15,9 @@ import org.reactivestreams.Publisher
 
 object Flowables {
 
+    @Deprecated("New type inference algorithm in Kotlin 1.4 makes this method obsolete. Method will be removed in future RxKotlin release.",
+            replaceWith = ReplaceWith("Flowable.combineLatest(source1, source2, combineFunction)", "io.reactivex.Flowable"),
+            level = DeprecationLevel.WARNING)
     @CheckReturnValue
     @BackpressureSupport(BackpressureKind.FULL)
     @SchedulerSupport(SchedulerSupport.NONE)
@@ -38,6 +41,9 @@ object Flowables {
             BiFunction<T1, T2, Pair<T1, T2>> { t1, t2 -> t1 to t2 })
 
 
+    @Deprecated("New type inference algorithm in Kotlin 1.4 makes this method obsolete. Method will be removed in future RxKotlin release.",
+            replaceWith = ReplaceWith("Flowable.combineLatest(source1, source2, source3, combineFunction)", "io.reactivex.Flowable"),
+            level = DeprecationLevel.WARNING)
     @CheckReturnValue
     @BackpressureSupport(BackpressureKind.FULL)
     @SchedulerSupport(SchedulerSupport.NONE)
@@ -63,6 +69,9 @@ object Flowables {
             Function3<T1, T2, T3, Triple<T1, T2, T3>> { t1, t2, t3 -> Triple(t1, t2, t3) })
 
 
+    @Deprecated("New type inference algorithm in Kotlin 1.4 makes this method obsolete. Method will be removed in future RxKotlin release.",
+            replaceWith = ReplaceWith("Flowable.combineLatest(source1, source2, source3, source4, combineFunction)", "io.reactivex.Flowable"),
+            level = DeprecationLevel.WARNING)
     @CheckReturnValue
     @BackpressureSupport(BackpressureKind.FULL)
     @SchedulerSupport(SchedulerSupport.NONE)
@@ -76,6 +85,9 @@ object Flowables {
             Function4 { t1: T1, t2: T2, t3: T3, t4: T4 -> combineFunction(t1, t2, t3, t4) })
 
 
+    @Deprecated("New type inference algorithm in Kotlin 1.4 makes this method obsolete. Method will be removed in future RxKotlin release.",
+            replaceWith = ReplaceWith("Flowable.combineLatest(source1, source2, source3, source4, source5, combineFunction)", "io.reactivex.Flowable"),
+            level = DeprecationLevel.WARNING)
     @CheckReturnValue
     @BackpressureSupport(BackpressureKind.FULL)
     @SchedulerSupport(SchedulerSupport.NONE)
@@ -90,6 +102,9 @@ object Flowables {
             Function5 { t1: T1, t2: T2, t3: T3, t4: T4, t5: T5 -> combineFunction(t1, t2, t3, t4, t5) })
 
 
+    @Deprecated("New type inference algorithm in Kotlin 1.4 makes this method obsolete. Method will be removed in future RxKotlin release.",
+            replaceWith = ReplaceWith("Flowable.combineLatest(source1, source2, source3, source4, source5, source6, combineFunction)", "io.reactivex.Flowable"),
+            level = DeprecationLevel.WARNING)
     @CheckReturnValue
     @BackpressureSupport(BackpressureKind.FULL)
     @SchedulerSupport(SchedulerSupport.NONE)
@@ -104,6 +119,9 @@ object Flowables {
     ): Flowable<R> = Flowable.combineLatest(source1, source2, source3, source4, source5, source6,
             Function6 { t1: T1, t2: T2, t3: T3, t4: T4, t5: T5, t6: T6 -> combineFunction(t1, t2, t3, t4, t5, t6) })
 
+    @Deprecated("New type inference algorithm in Kotlin 1.4 makes this method obsolete. Method will be removed in future RxKotlin release.",
+            replaceWith = ReplaceWith("Flowable.combineLatest(source1, source2, source3, source4, source5, source6, source7, combineFunction)", "io.reactivex.Flowable"),
+            level = DeprecationLevel.WARNING)
     @CheckReturnValue
     @BackpressureSupport(BackpressureKind.FULL)
     @SchedulerSupport(SchedulerSupport.NONE)
@@ -120,6 +138,9 @@ object Flowables {
             Function7 { t1: T1, t2: T2, t3: T3, t4: T4, t5: T5, t6: T6, t7: T7 -> combineFunction(t1, t2, t3, t4, t5, t6, t7) })
 
 
+    @Deprecated("New type inference algorithm in Kotlin 1.4 makes this method obsolete. Method will be removed in future RxKotlin release.",
+            replaceWith = ReplaceWith("Flowable.combineLatest(source1, source2, source3, source4, source5, source6, source7, source8, combineFunction)", "io.reactivex.Flowable"),
+            level = DeprecationLevel.WARNING)
     @CheckReturnValue
     @BackpressureSupport(BackpressureKind.FULL)
     @SchedulerSupport(SchedulerSupport.NONE)
@@ -136,6 +157,9 @@ object Flowables {
     ): Flowable<R> = Flowable.combineLatest(source1, source2, source3, source4, source5, source6, source7, source8,
             Function8 { t1: T1, t2: T2, t3: T3, t4: T4, t5: T5, t6: T6, t7: T7, t8: T8 -> combineFunction(t1, t2, t3, t4, t5, t6, t7, t8) })
 
+    @Deprecated("New type inference algorithm in Kotlin 1.4 makes this method obsolete. Method will be removed in future RxKotlin release.",
+            replaceWith = ReplaceWith("Flowable.combineLatest(source1, source2, source3, source4, source5, source6, source7, source8, source9, combineFunction)", "io.reactivex.Flowable"),
+            level = DeprecationLevel.WARNING)
     @CheckReturnValue
     @BackpressureSupport(BackpressureKind.FULL)
     @SchedulerSupport(SchedulerSupport.NONE)
@@ -162,7 +186,9 @@ object Flowables {
             crossinline source: (FlowableEmitter<T>) -> Unit
     ): Flowable<T> = Flowable.create({ source(it) }, mode)
 
-
+    @Deprecated("New type inference algorithm in Kotlin 1.4 makes this method obsolete. Method will be removed in future RxKotlin release.",
+            replaceWith = ReplaceWith("Flowable.zip(source1, source2, combineFunction)", "io.reactivex.Flowable"),
+            level = DeprecationLevel.WARNING)
     @CheckReturnValue
     @BackpressureSupport(BackpressureKind.FULL)
     @SchedulerSupport(SchedulerSupport.NONE)
@@ -183,6 +209,9 @@ object Flowables {
             Flowable.zip(source1, source2, BiFunction<T1, T2, Pair<T1, T2>> { t1, t2 -> t1 to t2 })
 
 
+    @Deprecated("New type inference algorithm in Kotlin 1.4 makes this method obsolete. Method will be removed in future RxKotlin release.",
+            replaceWith = ReplaceWith("Flowable.zip(source1, source2, source3, combineFunction)", "io.reactivex.Flowable"),
+            level = DeprecationLevel.WARNING)
     @CheckReturnValue
     @BackpressureSupport(BackpressureKind.FULL)
     @SchedulerSupport(SchedulerSupport.NONE)
@@ -207,6 +236,9 @@ object Flowables {
     ): Flowable<Triple<T1, T2, T3>> = Flowable.zip(source1, source2, source3,
             Function3<T1, T2, T3, Triple<T1, T2, T3>> { t1, t2, t3 -> Triple(t1, t2, t3) })
 
+    @Deprecated("New type inference algorithm in Kotlin 1.4 makes this method obsolete. Method will be removed in future RxKotlin release.",
+            replaceWith = ReplaceWith("Flowable.zip(source1, source2, source3, source4, combineFunction)", "io.reactivex.Flowable"),
+            level = DeprecationLevel.WARNING)
     @CheckReturnValue
     @BackpressureSupport(BackpressureKind.FULL)
     @SchedulerSupport(SchedulerSupport.NONE)
@@ -219,6 +251,9 @@ object Flowables {
     ): Flowable<R> = Flowable.zip(source1, source2, source3, source4,
             Function4 { t1: T1, t2: T2, t3: T3, t4: T4 -> combineFunction(t1, t2, t3, t4) })
 
+    @Deprecated("New type inference algorithm in Kotlin 1.4 makes this method obsolete. Method will be removed in future RxKotlin release.",
+            replaceWith = ReplaceWith("Flowable.zip(source1, source2, source3, source4, source5, combineFunction)", "io.reactivex.Flowable"),
+            level = DeprecationLevel.WARNING)
     @CheckReturnValue
     @BackpressureSupport(BackpressureKind.FULL)
     @SchedulerSupport(SchedulerSupport.NONE)
@@ -230,6 +265,9 @@ object Flowables {
             Function5 { t1: T1, t2: T2, t3: T3, t4: T4, t5: T5 -> combineFunction(t1, t2, t3, t4, t5) })
 
 
+    @Deprecated("New type inference algorithm in Kotlin 1.4 makes this method obsolete. Method will be removed in future RxKotlin release.",
+            replaceWith = ReplaceWith("Flowable.zip(source1, source2, source3, source4, source5, source6, combineFunction)", "io.reactivex.Flowable"),
+            level = DeprecationLevel.WARNING)
     @CheckReturnValue
     @BackpressureSupport(BackpressureKind.FULL)
     @SchedulerSupport(SchedulerSupport.NONE)
@@ -240,6 +278,9 @@ object Flowables {
     ): Flowable<R> = Flowable.zip(source1, source2, source3, source4, source5, source6,
             Function6 { t1: T1, t2: T2, t3: T3, t4: T4, t5: T5, t6: T6 -> combineFunction(t1, t2, t3, t4, t5, t6) })
 
+    @Deprecated("New type inference algorithm in Kotlin 1.4 makes this method obsolete. Method will be removed in future RxKotlin release.",
+            replaceWith = ReplaceWith("Flowable.zip(source1, source2, source3, source4, source5, source6, source7, combineFunction)", "io.reactivex.Flowable"),
+            level = DeprecationLevel.WARNING)
     @CheckReturnValue
     @BackpressureSupport(BackpressureKind.FULL)
     @SchedulerSupport(SchedulerSupport.NONE)
@@ -252,6 +293,9 @@ object Flowables {
             Function7 { t1: T1, t2: T2, t3: T3, t4: T4, t5: T5, t6: T6, t7: T7 -> combineFunction(t1, t2, t3, t4, t5, t6, t7) })
 
 
+    @Deprecated("New type inference algorithm in Kotlin 1.4 makes this method obsolete. Method will be removed in future RxKotlin release.",
+            replaceWith = ReplaceWith("Flowable.zip(source1, source2, source3, source4, source5, source6, source7, source8, combineFunction)", "io.reactivex.Flowable"),
+            level = DeprecationLevel.WARNING)
     @CheckReturnValue
     @BackpressureSupport(BackpressureKind.FULL)
     @SchedulerSupport(SchedulerSupport.NONE)
@@ -264,6 +308,9 @@ object Flowables {
     ): Flowable<R> = Flowable.zip(source1, source2, source3, source4, source5, source6, source7, source8,
             Function8 { t1: T1, t2: T2, t3: T3, t4: T4, t5: T5, t6: T6, t7: T7, t8: T8 -> combineFunction(t1, t2, t3, t4, t5, t6, t7, t8) })
 
+    @Deprecated("New type inference algorithm in Kotlin 1.4 makes this method obsolete. Method will be removed in future RxKotlin release.",
+            replaceWith = ReplaceWith("Flowable.zip(source1, source2, source3, source4, source5, source6, source7, source8, source9, combineFunction)", "io.reactivex.Flowable"),
+            level = DeprecationLevel.WARNING)
     @CheckReturnValue
     @BackpressureSupport(BackpressureKind.FULL)
     @SchedulerSupport(SchedulerSupport.NONE)
@@ -286,6 +333,9 @@ object Flowables {
 /**
  * An alias to [Flowable.withLatestFrom], but allowing for cleaner lambda syntax.
  */
+@Deprecated("New type inference algorithm in Kotlin 1.4 makes this method obsolete. Method will be removed in future RxKotlin release.",
+        replaceWith = ReplaceWith("withLatestFrom(other, combiner)"),
+        level = DeprecationLevel.WARNING)
 @CheckReturnValue
 @BackpressureSupport(BackpressureKind.PASS_THROUGH)
 @SchedulerSupport(SchedulerSupport.NONE)
@@ -304,6 +354,9 @@ fun <T : Any, U : Any> Flowable<T>.withLatestFrom(other: Publisher<U>): Flowable
 /**
  * An alias to [Flowable.withLatestFrom], but allowing for cleaner lambda syntax.
  */
+@Deprecated("New type inference algorithm in Kotlin 1.4 makes this method obsolete. Method will be removed in future RxKotlin release.",
+        replaceWith = ReplaceWith("withLatestFrom(o1, o2, combiner)"),
+        level = DeprecationLevel.WARNING)
 @CheckReturnValue
 @BackpressureSupport(BackpressureKind.PASS_THROUGH)
 @SchedulerSupport(SchedulerSupport.NONE)
@@ -324,6 +377,9 @@ fun <T : Any, T1 : Any, T2 : Any> Flowable<T>.withLatestFrom(
 /**
  * An alias to [Flowable.withLatestFrom], but allowing for cleaner lambda syntax.
  */
+@Deprecated("New type inference algorithm in Kotlin 1.4 makes this method obsolete. Method will be removed in future RxKotlin release.",
+        replaceWith = ReplaceWith("withLatestFrom(o1, o2, o3, combiner)"),
+        level = DeprecationLevel.WARNING)
 @CheckReturnValue
 @BackpressureSupport(BackpressureKind.PASS_THROUGH)
 @SchedulerSupport(SchedulerSupport.NONE)
@@ -337,6 +393,9 @@ inline fun <T : Any, T1 : Any, T2 : Any, T3 : Any, R : Any> Flowable<T>.withLate
 /**
  * An alias to [Flowable.withLatestFrom], but allowing for cleaner lambda syntax.
  */
+@Deprecated("New type inference algorithm in Kotlin 1.4 makes this method obsolete. Method will be removed in future RxKotlin release.",
+        replaceWith = ReplaceWith("withLatestFrom(o1, o2, o3, o4, combiner)"),
+        level = DeprecationLevel.WARNING)
 @CheckReturnValue
 @BackpressureSupport(BackpressureKind.FULL)
 @SchedulerSupport(SchedulerSupport.NONE)
@@ -351,6 +410,9 @@ inline fun <T : Any, T1 : Any, T2 : Any, T3 : Any, T4 : Any, R : Any> Flowable<T
 /**
  * An alias to [Flowable.zipWith], but allowing for cleaner lambda syntax.
  */
+@Deprecated("New type inference algorithm in Kotlin 1.4 makes this method obsolete. Method will be removed in future RxKotlin release.",
+        replaceWith = ReplaceWith("zipWith(other, zipper)"),
+        level = DeprecationLevel.WARNING)
 @CheckReturnValue
 @BackpressureSupport(BackpressureKind.PASS_THROUGH)
 @SchedulerSupport(SchedulerSupport.NONE)

--- a/src/main/kotlin/io/reactivex/rxjava3/kotlin/Maybes.kt
+++ b/src/main/kotlin/io/reactivex/rxjava3/kotlin/Maybes.kt
@@ -9,6 +9,10 @@ import io.reactivex.rxjava3.core.MaybeSource
 import io.reactivex.rxjava3.functions.*
 
 object Maybes {
+
+    @Deprecated("New type inference algorithm in Kotlin 1.4 makes this method obsolete. Method will be removed in future RxKotlin release.",
+            replaceWith = ReplaceWith("Maybe.zip(s1, s2, zipper)", "io.reactivex.Maybe"),
+            level = DeprecationLevel.WARNING)
     @CheckReturnValue
     @SchedulerSupport(SchedulerSupport.NONE)
     inline fun <T : Any, U : Any, R : Any> zip(
@@ -27,6 +31,9 @@ object Maybes {
             BiFunction { t, u -> Pair(t, u) })
 
 
+    @Deprecated("New type inference algorithm in Kotlin 1.4 makes this method obsolete. Method will be removed in future RxKotlin release.",
+            replaceWith = ReplaceWith("Maybe.zip(s1, s2, s3, zipper)", "io.reactivex.Maybe"),
+            level = DeprecationLevel.WARNING)
     @CheckReturnValue
     @SchedulerSupport(SchedulerSupport.NONE)
     inline fun <T1 : Any, T2 : Any, T3 : Any, R : Any>
@@ -46,6 +53,9 @@ object Maybes {
     ): Maybe<Triple<T1, T2, T3>> = Maybe.zip(s1, s2, s3,
             Function3 { t1, t2, t3 -> Triple(t1, t2, t3) })
 
+    @Deprecated("New type inference algorithm in Kotlin 1.4 makes this method obsolete. Method will be removed in future RxKotlin release.",
+            replaceWith = ReplaceWith("Maybe.zip(s1, s2, s3, s4, zipper)", "io.reactivex.Maybe"),
+            level = DeprecationLevel.WARNING)
     @CheckReturnValue
     @SchedulerSupport(SchedulerSupport.NONE)
     inline fun <T1 : Any, T2 : Any, T3 : Any, T4 : Any, R : Any>
@@ -56,6 +66,9 @@ object Maybes {
     ): Maybe<R> = Maybe.zip(s1, s2, s3, s4,
             Function4 { t1, t2, t3, t4 -> zipper.invoke(t1, t2, t3, t4) })
 
+    @Deprecated("New type inference algorithm in Kotlin 1.4 makes this method obsolete. Method will be removed in future RxKotlin release.",
+            replaceWith = ReplaceWith("Maybe.zip(s1, s2, s3, s4, s5, zipper)", "io.reactivex.Maybe"),
+            level = DeprecationLevel.WARNING)
     @CheckReturnValue
     @SchedulerSupport(SchedulerSupport.NONE)
     inline fun <T1 : Any, T2 : Any, T3 : Any, T4 : Any, T5 : Any, R : Any>
@@ -67,6 +80,9 @@ object Maybes {
     ): Maybe<R> = Maybe.zip(s1, s2, s3, s4, s5,
             Function5 { t1, t2, t3, t4, t5 -> zipper.invoke(t1, t2, t3, t4, t5) })
 
+    @Deprecated("New type inference algorithm in Kotlin 1.4 makes this method obsolete. Method will be removed in future RxKotlin release.",
+            replaceWith = ReplaceWith("Maybe.zip(s1, s2, s3, s4, s5, s6, zipper)", "io.reactivex.Maybe"),
+            level = DeprecationLevel.WARNING)
     @CheckReturnValue
     @SchedulerSupport(SchedulerSupport.NONE)
     inline fun <T1 : Any, T2 : Any, T3 : Any, T4 : Any, T5 : Any, T6 : Any, R : Any>
@@ -78,6 +94,9 @@ object Maybes {
     ): Maybe<R> = Maybe.zip(s1, s2, s3, s4, s5, s6,
             Function6 { t1, t2, t3, t4, t5, t6 -> zipper.invoke(t1, t2, t3, t4, t5, t6) })
 
+    @Deprecated("New type inference algorithm in Kotlin 1.4 makes this method obsolete. Method will be removed in future RxKotlin release.",
+            replaceWith = ReplaceWith("Maybe.zip(s1, s2, s3, s4, s5, s6, s7, zipper)", "io.reactivex.Maybe"),
+            level = DeprecationLevel.WARNING)
     @CheckReturnValue
     @SchedulerSupport(SchedulerSupport.NONE)
     inline fun <T1 : Any, T2 : Any, T3 : Any, T4 : Any, T5 : Any, T6 : Any, T7 : Any, R : Any>
@@ -90,6 +109,9 @@ object Maybes {
     ): Maybe<R> = Maybe.zip(s1, s2, s3, s4, s5, s6, s7,
             Function7 { t1, t2, t3, t4, t5, t6, t7 -> zipper.invoke(t1, t2, t3, t4, t5, t6, t7) })
 
+    @Deprecated("New type inference algorithm in Kotlin 1.4 makes this method obsolete. Method will be removed in future RxKotlin release.",
+            replaceWith = ReplaceWith("Maybe.zip(s1, s2, s3, s4, s5, s6, s7, s8, zipper)", "io.reactivex.Maybe"),
+            level = DeprecationLevel.WARNING)
     @CheckReturnValue
     @SchedulerSupport(SchedulerSupport.NONE)
     inline fun <T1 : Any, T2 : Any, T3 : Any, T4 : Any, T5 : Any, T6 : Any, T7 : Any, T8 : Any, R : Any>
@@ -102,6 +124,9 @@ object Maybes {
     ): Maybe<R> = Maybe.zip(s1, s2, s3, s4, s5, s6, s7, s8,
             Function8 { t1, t2, t3, t4, t5, t6, t7, t8 -> zipper.invoke(t1, t2, t3, t4, t5, t6, t7, t8) })
 
+    @Deprecated("New type inference algorithm in Kotlin 1.4 makes this method obsolete. Method will be removed in future RxKotlin release.",
+            replaceWith = ReplaceWith("Maybe.zip(s1, s2, s3, s4, s5, s6, s7, s8, s9, zipper)", "io.reactivex.Maybe"),
+            level = DeprecationLevel.WARNING)
     @CheckReturnValue
     @SchedulerSupport(SchedulerSupport.NONE)
     inline fun <T1 : Any, T2 : Any, T3 : Any, T4 : Any, T5 : Any, T6 : Any, T7 : Any, T8 : Any, T9 : Any, R : Any>
@@ -119,6 +144,9 @@ object Maybes {
 /**
  * An alias to [Maybe.zipWith], but allowing for cleaner lambda syntax.
  */
+@Deprecated("New type inference algorithm in Kotlin 1.4 makes this method obsolete. Method will be removed in future RxKotlin release.",
+        replaceWith = ReplaceWith("zipWith(other, zipper)"),
+        level = DeprecationLevel.WARNING)
 @CheckReturnValue
 @SchedulerSupport(SchedulerSupport.NONE)
 inline fun <T : Any, U : Any, R : Any> Maybe<T>.zipWith(

--- a/src/main/kotlin/io/reactivex/rxjava3/kotlin/Observables.kt
+++ b/src/main/kotlin/io/reactivex/rxjava3/kotlin/Observables.kt
@@ -13,6 +13,9 @@ import io.reactivex.rxjava3.functions.*
  */
 object Observables {
 
+    @Deprecated("New type inference algorithm in Kotlin 1.4 makes this method obsolete. Method will be removed in future RxKotlin release.",
+            replaceWith = ReplaceWith("Observable.combineLatest(source1, source2, combineFunction)", "io.reactivex.Observable"),
+            level = DeprecationLevel.WARNING)
     @CheckReturnValue
     @SchedulerSupport(SchedulerSupport.NONE)
     inline fun <T1 : Any, T2 : Any, R : Any> combineLatest(
@@ -31,6 +34,9 @@ object Observables {
             Observable.combineLatest(source1, source2,
                     BiFunction<T1, T2, Pair<T1, T2>> { t1, t2 -> t1 to t2 })
 
+    @Deprecated("New type inference algorithm in Kotlin 1.4 makes this method obsolete. Method will be removed in future RxKotlin release.",
+            replaceWith = ReplaceWith("Observable.combineLatest(source1, source2, source3, combineFunction)", "io.reactivex.Observable"),
+            level = DeprecationLevel.WARNING)
     @CheckReturnValue
     @SchedulerSupport(SchedulerSupport.NONE)
     inline fun <T1 : Any, T2 : Any, T3 : Any, R : Any> combineLatest(
@@ -53,6 +59,9 @@ object Observables {
     ): Observable<Triple<T1, T2, T3>> = Observable.combineLatest(source1, source2, source3,
             Function3<T1, T2, T3, Triple<T1, T2, T3>> { t1, t2, t3 -> Triple(t1, t2, t3) })
 
+    @Deprecated("New type inference algorithm in Kotlin 1.4 makes this method obsolete. Method will be removed in future RxKotlin release.",
+            replaceWith = ReplaceWith("Observable.combineLatest(source1, source2, source3, source4, combineFunction)", "io.reactivex.Observable"),
+            level = DeprecationLevel.WARNING)
     @CheckReturnValue
     @SchedulerSupport(SchedulerSupport.NONE)
     inline fun <T1 : Any, T2 : Any, T3 : Any, T4 : Any, R : Any> combineLatest(
@@ -62,6 +71,9 @@ object Observables {
             Function4 { t1: T1, t2: T2, t3: T3, t4: T4 -> combineFunction(t1, t2, t3, t4) })
 
 
+    @Deprecated("New type inference algorithm in Kotlin 1.4 makes this method obsolete. Method will be removed in future RxKotlin release.",
+            replaceWith = ReplaceWith("Observable.combineLatest(source1, source2, source3, source4, source5, combineFunction)", "io.reactivex.Observable"),
+            level = DeprecationLevel.WARNING)
     @CheckReturnValue
     @SchedulerSupport(SchedulerSupport.NONE)
     inline fun <T1 : Any, T2 : Any, T3 : Any, T4 : Any, T5 : Any, R : Any> combineLatest(
@@ -72,6 +84,9 @@ object Observables {
             Function5 { t1: T1, t2: T2, t3: T3, t4: T4, t5: T5 -> combineFunction(t1, t2, t3, t4, t5) })
 
 
+    @Deprecated("New type inference algorithm in Kotlin 1.4 makes this method obsolete. Method will be removed in future RxKotlin release.",
+            replaceWith = ReplaceWith("Observable.combineLatest(source1, source2, source3, source4, source5, source6, combineFunction)", "io.reactivex.Observable"),
+            level = DeprecationLevel.WARNING)
     @CheckReturnValue
     @SchedulerSupport(SchedulerSupport.NONE)
     inline fun <T1 : Any, T2 : Any, T3 : Any, T4 : Any, T5 : Any, T6 : Any, R : Any> combineLatest(
@@ -81,6 +96,9 @@ object Observables {
     ): Observable<R> = Observable.combineLatest(source1, source2, source3, source4, source5, source6,
             Function6 { t1: T1, t2: T2, t3: T3, t4: T4, t5: T5, t6: T6 -> combineFunction(t1, t2, t3, t4, t5, t6) })
 
+    @Deprecated("New type inference algorithm in Kotlin 1.4 makes this method obsolete. Method will be removed in future RxKotlin release.",
+            replaceWith = ReplaceWith("Observable.combineLatest(source1, source2, source3, source4, source5, source6, source7, combineFunction)", "io.reactivex.Observable"),
+            level = DeprecationLevel.WARNING)
     @CheckReturnValue
     @SchedulerSupport(SchedulerSupport.NONE)
     inline fun <T1 : Any, T2 : Any, T3 : Any, T4 : Any, T5 : Any, T6 : Any, T7 : Any, R : Any> combineLatest(
@@ -92,6 +110,9 @@ object Observables {
             Function7 { t1: T1, t2: T2, t3: T3, t4: T4, t5: T5, t6: T6, t7: T7 -> combineFunction(t1, t2, t3, t4, t5, t6, t7) })
 
 
+    @Deprecated("New type inference algorithm in Kotlin 1.4 makes this method obsolete. Method will be removed in future RxKotlin release.",
+            replaceWith = ReplaceWith("Observable.combineLatest(source1, source2, source3, source4, source5, source6, source7, source8, combineFunction)", "io.reactivex.Observable"),
+            level = DeprecationLevel.WARNING)
     @CheckReturnValue
     @SchedulerSupport(SchedulerSupport.NONE)
     inline fun <T1 : Any, T2 : Any, T3 : Any, T4 : Any, T5 : Any, T6 : Any, T7 : Any, T8 : Any, R : Any> combineLatest(
@@ -103,6 +124,9 @@ object Observables {
     ): Observable<R> = Observable.combineLatest(source1, source2, source3, source4, source5, source6, source7, source8,
             Function8 { t1: T1, t2: T2, t3: T3, t4: T4, t5: T5, t6: T6, t7: T7, t8: T8 -> combineFunction(t1, t2, t3, t4, t5, t6, t7, t8) })
 
+    @Deprecated("New type inference algorithm in Kotlin 1.4 makes this method obsolete. Method will be removed in future RxKotlin release.",
+            replaceWith = ReplaceWith("Observable.combineLatest(source1, source2, source3, source4, source5, source6, source7, source8, source9, combineFunction)", "io.reactivex.Observable"),
+            level = DeprecationLevel.WARNING)
     @CheckReturnValue
     @SchedulerSupport(SchedulerSupport.NONE)
     inline fun <T1 : Any, T2 : Any, T3 : Any, T4 : Any, T5 : Any, T6 : Any, T7 : Any, T8 : Any, T9 : Any, R : Any> combineLatest(
@@ -115,6 +139,9 @@ object Observables {
             Function9 { t1: T1, t2: T2, t3: T3, t4: T4, t5: T5, t6: T6, t7: T7, t8: T8, t9: T9 -> combineFunction(t1, t2, t3, t4, t5, t6, t7, t8, t9) })
 
 
+    @Deprecated("New type inference algorithm in Kotlin 1.4 makes this method obsolete. Method will be removed in future RxKotlin release.",
+            replaceWith = ReplaceWith("Observable.zip(source1, source2, combineFunction)", "io.reactivex.Observable"),
+            level = DeprecationLevel.WARNING)
     @CheckReturnValue
     @SchedulerSupport(SchedulerSupport.NONE)
     inline fun <T1 : Any, T2 : Any, R : Any> zip(
@@ -134,6 +161,9 @@ object Observables {
             Observable.zip(source1, source2,
                     BiFunction<T1, T2, Pair<T1, T2>> { t1, t2 -> t1 to t2 })
 
+    @Deprecated("New type inference algorithm in Kotlin 1.4 makes this method obsolete. Method will be removed in future RxKotlin release.",
+            replaceWith = ReplaceWith("Observable.zip(source1, source2, source3, combineFunction)", "io.reactivex.Observable"),
+            level = DeprecationLevel.WARNING)
     @CheckReturnValue
     @SchedulerSupport(SchedulerSupport.NONE)
     inline fun <T1 : Any, T2 : Any, T3 : Any, R : Any> zip(
@@ -156,6 +186,9 @@ object Observables {
     ): Observable<Triple<T1, T2, T3>> = Observable.zip(source1, source2, source3,
             Function3<T1, T2, T3, Triple<T1, T2, T3>> { t1, t2, t3 -> Triple(t1, t2, t3) })
 
+    @Deprecated("New type inference algorithm in Kotlin 1.4 makes this method obsolete. Method will be removed in future RxKotlin release.",
+            replaceWith = ReplaceWith("Observable.zip(source1, source2, source3, source4, combineFunction)", "io.reactivex.Observable"),
+            level = DeprecationLevel.WARNING)
     @CheckReturnValue
     @SchedulerSupport(SchedulerSupport.NONE)
     inline fun <T1 : Any, T2 : Any, T3 : Any, T4 : Any, R : Any> zip(
@@ -167,6 +200,9 @@ object Observables {
     ): Observable<R> = Observable.zip(source1, source2, source3, source4,
             Function4 { t1: T1, t2: T2, t3: T3, t4: T4 -> combineFunction(t1, t2, t3, t4) })
 
+    @Deprecated("New type inference algorithm in Kotlin 1.4 makes this method obsolete. Method will be removed in future RxKotlin release.",
+            replaceWith = ReplaceWith("Observable.zip(source1, source2, source3, source4, source5, combineFunction)", "io.reactivex.Observable"),
+            level = DeprecationLevel.WARNING)
     @CheckReturnValue
     @SchedulerSupport(SchedulerSupport.NONE)
     inline fun <T1 : Any, T2 : Any, T3 : Any, T4 : Any, T5 : Any, R : Any> zip(
@@ -177,6 +213,9 @@ object Observables {
             Function5 { t1: T1, t2: T2, t3: T3, t4: T4, t5: T5 -> combineFunction(t1, t2, t3, t4, t5) })
 
 
+    @Deprecated("New type inference algorithm in Kotlin 1.4 makes this method obsolete. Method will be removed in future RxKotlin release.",
+            replaceWith = ReplaceWith("Observable.zip(source1, source2, source3, source4, source5, source6, combineFunction)", "io.reactivex.Observable"),
+            level = DeprecationLevel.WARNING)
     @CheckReturnValue
     @SchedulerSupport(SchedulerSupport.NONE)
     inline fun <T1 : Any, T2 : Any, T3 : Any, T4 : Any, T5 : Any, T6 : Any, R : Any> zip(
@@ -186,6 +225,9 @@ object Observables {
     ): Observable<R> = Observable.zip(source1, source2, source3, source4, source5, source6,
             Function6 { t1: T1, t2: T2, t3: T3, t4: T4, t5: T5, t6: T6 -> combineFunction(t1, t2, t3, t4, t5, t6) })
 
+    @Deprecated("New type inference algorithm in Kotlin 1.4 makes this method obsolete. Method will be removed in future RxKotlin release.",
+            replaceWith = ReplaceWith("Observable.zip(source1, source2, source3, source4, source5, source6, source7, combineFunction)", "io.reactivex.Observable"),
+            level = DeprecationLevel.WARNING)
     @CheckReturnValue
     @SchedulerSupport(SchedulerSupport.NONE)
     inline fun <T1 : Any, T2 : Any, T3 : Any, T4 : Any, T5 : Any, T6 : Any, T7 : Any, R : Any> zip(
@@ -196,7 +238,9 @@ object Observables {
     ): Observable<R> = Observable.zip(source1, source2, source3, source4, source5, source6, source7,
             Function7 { t1: T1, t2: T2, t3: T3, t4: T4, t5: T5, t6: T6, t7: T7 -> combineFunction(t1, t2, t3, t4, t5, t6, t7) })
 
-
+    @Deprecated("New type inference algorithm in Kotlin 1.4 makes this method obsolete. Method will be removed in future RxKotlin release.",
+            replaceWith = ReplaceWith("Observable.zip(source1, source2, source3, source4, source5, source6, source7, source8, combineFunction)", "io.reactivex.Observable"),
+            level = DeprecationLevel.WARNING)
     @CheckReturnValue
     @SchedulerSupport(SchedulerSupport.NONE)
     inline fun <T1 : Any, T2 : Any, T3 : Any, T4 : Any, T5 : Any, T6 : Any, T7 : Any, T8 : Any, R : Any> zip(
@@ -208,6 +252,9 @@ object Observables {
     ): Observable<R> = Observable.zip(source1, source2, source3, source4, source5, source6, source7, source8,
             Function8 { t1: T1, t2: T2, t3: T3, t4: T4, t5: T5, t6: T6, t7: T7, t8: T8 -> combineFunction(t1, t2, t3, t4, t5, t6, t7, t8) })
 
+    @Deprecated("New type inference algorithm in Kotlin 1.4 makes this method obsolete. Method will be removed in future RxKotlin release.",
+            replaceWith = ReplaceWith("Observable.zip(source1, source2, source3, source4, source5, source6, source7, source8, source9, combineFunction)", "io.reactivex.Observable"),
+            level = DeprecationLevel.WARNING)
     @CheckReturnValue
     @SchedulerSupport(SchedulerSupport.NONE)
     inline fun <T1 : Any, T2 : Any, T3 : Any, T4 : Any, T5 : Any, T6 : Any, T7 : Any, T8 : Any, T9 : Any, R : Any> zip(
@@ -225,6 +272,9 @@ object Observables {
 /**
  * An alias to [Observable.withLatestFrom], but allowing for cleaner lambda syntax.
  */
+@Deprecated("New type inference algorithm in Kotlin 1.4 makes this method obsolete. Method will be removed in future RxKotlin release.",
+        replaceWith = ReplaceWith("withLatestFrom(other, combiner)"),
+        level = DeprecationLevel.WARNING)
 @CheckReturnValue
 @SchedulerSupport(SchedulerSupport.NONE)
 inline fun <T : Any, U : Any, R : Any> Observable<T>.withLatestFrom(
@@ -243,6 +293,9 @@ fun <T : Any, U : Any> Observable<T>.withLatestFrom(other: ObservableSource<U>):
 /**
  * An alias to [Observable.withLatestFrom], but allowing for cleaner lambda syntax.
  */
+@Deprecated("New type inference algorithm in Kotlin 1.4 makes this method obsolete. Method will be removed in future RxKotlin release.",
+        replaceWith = ReplaceWith("withLatestFrom(o1, o2, combiner)"),
+        level = DeprecationLevel.WARNING)
 @CheckReturnValue
 @SchedulerSupport(SchedulerSupport.NONE)
 inline fun <T : Any, T1 : Any, T2 : Any, R : Any> Observable<T>.withLatestFrom(
@@ -261,6 +314,9 @@ fun <T : Any, T1 : Any, T2 : Any> Observable<T>.withLatestFrom(
 /**
  * An alias to [Observable.withLatestFrom], but allowing for cleaner lambda syntax.
  */
+@Deprecated("New type inference algorithm in Kotlin 1.4 makes this method obsolete. Method will be removed in future RxKotlin release.",
+        replaceWith = ReplaceWith("withLatestFrom(o1, o2, o3, combiner)"),
+        level = DeprecationLevel.WARNING)
 @CheckReturnValue
 @SchedulerSupport(SchedulerSupport.NONE)
 inline fun <T : Any, T1 : Any, T2 : Any, T3 : Any, R : Any> Observable<T>.withLatestFrom(
@@ -273,6 +329,9 @@ inline fun <T : Any, T1 : Any, T2 : Any, T3 : Any, R : Any> Observable<T>.withLa
 /**
  * An alias to [Observable.withLatestFrom], but allowing for cleaner lambda syntax.
  */
+@Deprecated("New type inference algorithm in Kotlin 1.4 makes this method obsolete. Method will be removed in future RxKotlin release.",
+        replaceWith = ReplaceWith("withLatestFrom(o1, o2, o3, o4, combiner)"),
+        level = DeprecationLevel.WARNING)
 @CheckReturnValue
 @SchedulerSupport(SchedulerSupport.NONE)
 inline fun <T : Any, T1 : Any, T2 : Any, T3 : Any, T4 : Any, R : Any> Observable<T>.withLatestFrom(
@@ -287,6 +346,9 @@ inline fun <T : Any, T1 : Any, T2 : Any, T3 : Any, T4 : Any, R : Any> Observable
 /**
  * An alias to [Observable.zipWith], but allowing for cleaner lambda syntax.
  */
+@Deprecated("New type inference algorithm in Kotlin 1.4 makes this method obsolete. Method will be removed in future RxKotlin release.",
+        replaceWith = ReplaceWith("zipWith(other, zipper)"),
+        level = DeprecationLevel.WARNING)
 @CheckReturnValue
 @SchedulerSupport(SchedulerSupport.NONE)
 inline fun <T : Any, U : Any, R : Any> Observable<T>.zipWith(

--- a/src/main/kotlin/io/reactivex/rxjava3/kotlin/Singles.kt
+++ b/src/main/kotlin/io/reactivex/rxjava3/kotlin/Singles.kt
@@ -8,6 +8,10 @@ import io.reactivex.rxjava3.functions.*
 
 
 object Singles {
+
+    @Deprecated("New type inference algorithm in Kotlin 1.4 makes this method obsolete. Method will be removed in future RxKotlin release.",
+            replaceWith = ReplaceWith("Single.zip(s1, s2, zipper)", "io.reactivex.Single"),
+            level = DeprecationLevel.WARNING)
     @CheckReturnValue
     @SchedulerSupport(SchedulerSupport.NONE)
     inline fun <T : Any, U : Any, R : Any> zip(
@@ -24,6 +28,9 @@ object Singles {
     ): Single<Pair<T, U>> = Single.zip(s1, s2, BiFunction { t, u -> Pair(t, u) })
 
 
+    @Deprecated("New type inference algorithm in Kotlin 1.4 makes this method obsolete. Method will be removed in future RxKotlin release.",
+            replaceWith = ReplaceWith("Single.zip(s1, s2, s3, zipper)", "io.reactivex.Single"),
+            level = DeprecationLevel.WARNING)
     @CheckReturnValue
     @SchedulerSupport(SchedulerSupport.NONE)
     inline fun <T1 : Any, T2 : Any, T3 : Any, R : Any>
@@ -41,6 +48,9 @@ object Singles {
             s3: SingleSource<T3>
     ): Single<Triple<T1, T2, T3>> = Single.zip(s1, s2, s3, Function3 { t1, t2, t3 -> Triple(t1, t2, t3) })
 
+    @Deprecated("New type inference algorithm in Kotlin 1.4 makes this method obsolete. Method will be removed in future RxKotlin release.",
+            replaceWith = ReplaceWith("Single.zip(s1, s2, s3, s4, zipper)", "io.reactivex.Single"),
+            level = DeprecationLevel.WARNING)
     @CheckReturnValue
     @SchedulerSupport(SchedulerSupport.NONE)
     inline fun <T1 : Any, T2 : Any, T3 : Any, T4 : Any, R : Any>
@@ -51,6 +61,9 @@ object Singles {
     ): Single<R> = Single.zip(s1, s2, s3, s4,
             Function4 { t1, t2, t3, t4 -> zipper.invoke(t1, t2, t3, t4) })
 
+    @Deprecated("New type inference algorithm in Kotlin 1.4 makes this method obsolete. Method will be removed in future RxKotlin release.",
+            replaceWith = ReplaceWith("Single.zip(s1, s2, s3, s4, s5, zipper)", "io.reactivex.Single"),
+            level = DeprecationLevel.WARNING)
     @CheckReturnValue
     @SchedulerSupport(SchedulerSupport.NONE)
     inline fun <T1 : Any, T2 : Any, T3 : Any, T4 : Any, T5 : Any, R : Any>
@@ -62,6 +75,9 @@ object Singles {
     ): Single<R> = Single.zip(s1, s2, s3, s4, s5,
             Function5 { t1, t2, t3, t4, t5 -> zipper.invoke(t1, t2, t3, t4, t5) })
 
+    @Deprecated("New type inference algorithm in Kotlin 1.4 makes this method obsolete. Method will be removed in future RxKotlin release.",
+            replaceWith = ReplaceWith("Single.zip(s1, s2, s3, s4, s5, s6, zipper)", "io.reactivex.Single"),
+            level = DeprecationLevel.WARNING)
     @CheckReturnValue
     @SchedulerSupport(SchedulerSupport.NONE)
     inline fun <T1 : Any, T2 : Any, T3 : Any, T4 : Any, T5 : Any, T6 : Any, R : Any>
@@ -73,6 +89,9 @@ object Singles {
     ): Single<R> = Single.zip(s1, s2, s3, s4, s5, s6,
             Function6 { t1, t2, t3, t4, t5, t6 -> zipper.invoke(t1, t2, t3, t4, t5, t6) })
 
+    @Deprecated("New type inference algorithm in Kotlin 1.4 makes this method obsolete. Method will be removed in future RxKotlin release.",
+            replaceWith = ReplaceWith("Single.zip(s1, s2, s3, s4, s5, s6, s7, zipper)", "io.reactivex.Single"),
+            level = DeprecationLevel.WARNING)
     @CheckReturnValue
     @SchedulerSupport(SchedulerSupport.NONE)
     inline fun <T1 : Any, T2 : Any, T3 : Any, T4 : Any, T5 : Any, T6 : Any, T7 : Any, R : Any>
@@ -85,6 +104,9 @@ object Singles {
     ): Single<R> = Single.zip(s1, s2, s3, s4, s5, s6, s7,
             Function7 { t1, t2, t3, t4, t5, t6, t7 -> zipper.invoke(t1, t2, t3, t4, t5, t6, t7) })
 
+    @Deprecated("New type inference algorithm in Kotlin 1.4 makes this method obsolete. Method will be removed in future RxKotlin release.",
+            replaceWith = ReplaceWith("Single.zip(s1, s2, s3, s4, s5, s6, s7, s8, zipper)", "io.reactivex.Single"),
+            level = DeprecationLevel.WARNING)
     @CheckReturnValue
     @SchedulerSupport(SchedulerSupport.NONE)
     inline fun <T1 : Any, T2 : Any, T3 : Any, T4 : Any, T5 : Any, T6 : Any, T7 : Any, T8 : Any, R : Any>
@@ -97,6 +119,9 @@ object Singles {
     ): Single<R> = Single.zip(s1, s2, s3, s4, s5, s6, s7, s8,
             Function8 { t1, t2, t3, t4, t5, t6, t7, t8 -> zipper.invoke(t1, t2, t3, t4, t5, t6, t7, t8) })
 
+    @Deprecated("New type inference algorithm in Kotlin 1.4 makes this method obsolete. Method will be removed in future RxKotlin release.",
+            replaceWith = ReplaceWith("Single.zip(s1, s2, s3, s4, s5, s6, s7, s8, s9, zipper)", "io.reactivex.Single"),
+            level = DeprecationLevel.WARNING)
     @CheckReturnValue
     @SchedulerSupport(SchedulerSupport.NONE)
     inline fun <T1 : Any, T2 : Any, T3 : Any, T4 : Any, T5 : Any, T6 : Any, T7 : Any, T8 : Any, T9 : Any, R : Any>
@@ -111,6 +136,9 @@ object Singles {
             Function9 { t1, t2, t3, t4, t5, t6, t7, t8, t9 -> zipper.invoke(t1, t2, t3, t4, t5, t6, t7, t8, t9) })
 }
 
+@Deprecated("New type inference algorithm in Kotlin 1.4 makes this method obsolete. Method will be removed in future RxKotlin release.",
+        replaceWith = ReplaceWith("zipWith(other, zipper)"),
+        level = DeprecationLevel.WARNING)
 @CheckReturnValue
 @SchedulerSupport(SchedulerSupport.NONE)
 inline fun <T : Any, U : Any, R : Any> Single<T>.zipWith(


### PR DESCRIPTION
Add deprecation warnings (with appropriate _replaceWith_ parameters) to SAM helper functions, which were made obsolete with new type inference in Kotlin 1.4.

Updated to Kotlin 1.4.