### PR TITLE
Add Flowables.combineLatest() and Flowables.zip() with additional parameters (2.x)

### DIFF
--- a/src/main/kotlin/io/reactivex/rxkotlin/Flowables.kt
+++ b/src/main/kotlin/io/reactivex/rxkotlin/Flowables.kt
@@ -10,6 +10,7 @@ import io.reactivex.annotations.BackpressureSupport
 import io.reactivex.annotations.CheckReturnValue
 import io.reactivex.annotations.SchedulerSupport
 import io.reactivex.functions.*
+import io.reactivex.internal.functions.Functions
 import org.reactivestreams.Publisher
 
 
@@ -25,6 +26,18 @@ object Flowables {
     ): Flowable<R> = Flowable.combineLatest(source1, source2,
             BiFunction<T1, T2, R> { t1, t2 -> combineFunction(t1, t2) })
 
+    @CheckReturnValue
+    @BackpressureSupport(BackpressureKind.FULL)
+    @SchedulerSupport(SchedulerSupport.NONE)
+    fun <T1 : Any, T2 : Any, R : Any> combineLatest(
+            source1: Flowable<T1>,
+            source2: Flowable<T2>,
+            bufferSize: Int,
+            combineFunction: (T1, T2) -> R
+    ): Flowable<R> = Flowable.combineLatest(listOf(source1, source2),
+            Functions.toFunction(combineFunction), bufferSize)
+
+
     /**
      * Emits `Pair<T1,T2>`
      */
@@ -37,6 +50,18 @@ object Flowables {
     ): Flowable<Pair<T1, T2>> = Flowable.combineLatest(source1, source2,
             BiFunction<T1, T2, Pair<T1, T2>> { t1, t2 -> t1 to t2 })
 
+    /**
+     * Emits `Pair<T1,T2>`
+     */
+    @CheckReturnValue
+    @BackpressureSupport(BackpressureKind.FULL)
+    @SchedulerSupport(SchedulerSupport.NONE)
+    fun <T1 : Any, T2 : Any> combineLatest(
+            source1: Flowable<T1>,
+            source2: Flowable<T2>,
+            bufferSize: Int
+    ): Flowable<Pair<T1, T2>> = combineLatest(source1, source2, bufferSize, ::Pair)
+
 
     @CheckReturnValue
     @BackpressureSupport(BackpressureKind.FULL)
@@ -48,6 +73,19 @@ object Flowables {
             crossinline combineFunction: (T1, T2, T3) -> R
     ): Flowable<R> = Flowable.combineLatest(source1, source2, source3,
             Function3 { t1: T1, t2: T2, t3: T3 -> combineFunction(t1, t2, t3) })
+
+    @CheckReturnValue
+    @BackpressureSupport(BackpressureKind.FULL)
+    @SchedulerSupport(SchedulerSupport.NONE)
+    fun <T1 : Any, T2 : Any, T3 : Any, R : Any> combineLatest(
+            source1: Flowable<T1>,
+            source2: Flowable<T2>,
+            source3: Flowable<T3>,
+            bufferSize: Int,
+            combineFunction: (T1, T2, T3) -> R
+    ): Flowable<R> = Flowable.combineLatest(listOf(source1, source2, source3),
+            Functions.toFunction(combineFunction), bufferSize)
+
 
     /**
      * Emits `Triple<T1,T2,T3>`
@@ -62,6 +100,20 @@ object Flowables {
     ): Flowable<Triple<T1, T2, T3>> = Flowable.combineLatest(source1, source2, source3,
             Function3<T1, T2, T3, Triple<T1, T2, T3>> { t1, t2, t3 -> Triple(t1, t2, t3) })
 
+    /**
+     * Emits `Triple<T1,T2,T3>`
+     */
+    @CheckReturnValue
+    @BackpressureSupport(BackpressureKind.FULL)
+    @SchedulerSupport(SchedulerSupport.NONE)
+    fun <T1 : Any, T2 : Any, T3 : Any, R : Any> combineLatest(
+            source1: Flowable<T1>,
+            source2: Flowable<T2>,
+            source3: Flowable<T3>,
+            bufferSize: Int
+    ): Flowable<Triple<T1, T2, T3>> =
+            combineLatest(source1, source2, source3, bufferSize, ::Triple)
+
 
     @CheckReturnValue
     @BackpressureSupport(BackpressureKind.FULL)
@@ -74,6 +126,19 @@ object Flowables {
             crossinline combineFunction: (T1, T2, T3, T4) -> R
     ): Flowable<R> = Flowable.combineLatest(source1, source2, source3, source4,
             Function4 { t1: T1, t2: T2, t3: T3, t4: T4 -> combineFunction(t1, t2, t3, t4) })
+
+    @CheckReturnValue
+    @BackpressureSupport(BackpressureKind.FULL)
+    @SchedulerSupport(SchedulerSupport.NONE)
+    fun <T1 : Any, T2 : Any, T3 : Any, T4 : Any, R : Any> combineLatest(
+            source1: Flowable<T1>,
+            source2: Flowable<T2>,
+            source3: Flowable<T3>,
+            source4: Flowable<T4>,
+            bufferSize: Int,
+            combineFunction: (T1, T2, T3, T4) -> R
+    ): Flowable<R> = Flowable.combineLatest(listOf(source1, source2, source3, source4),
+            Functions.toFunction(combineFunction), bufferSize)
 
 
     @CheckReturnValue
@@ -89,6 +154,20 @@ object Flowables {
     ): Flowable<R> = Flowable.combineLatest(source1, source2, source3, source4, source5,
             Function5 { t1: T1, t2: T2, t3: T3, t4: T4, t5: T5 -> combineFunction(t1, t2, t3, t4, t5) })
 
+    @CheckReturnValue
+    @BackpressureSupport(BackpressureKind.FULL)
+    @SchedulerSupport(SchedulerSupport.NONE)
+    fun <T1 : Any, T2 : Any, T3 : Any, T4 : Any, T5 : Any, R : Any> combineLatest(
+            source1: Flowable<T1>,
+            source2: Flowable<T2>,
+            source3: Flowable<T3>,
+            source4: Flowable<T4>,
+            source5: Flowable<T5>,
+            bufferSize: Int,
+            combineFunction: (T1, T2, T3, T4, T5) -> R
+    ): Flowable<R> = Flowable.combineLatest(listOf(source1, source2, source3, source4, source5),
+            Functions.toFunction(combineFunction), bufferSize)
+
 
     @CheckReturnValue
     @BackpressureSupport(BackpressureKind.FULL)
@@ -103,6 +182,41 @@ object Flowables {
             crossinline combineFunction: (T1, T2, T3, T4, T5, T6) -> R
     ): Flowable<R> = Flowable.combineLatest(source1, source2, source3, source4, source5, source6,
             Function6 { t1: T1, t2: T2, t3: T3, t4: T4, t5: T5, t6: T6 -> combineFunction(t1, t2, t3, t4, t5, t6) })
+
+    @CheckReturnValue
+    @BackpressureSupport(BackpressureKind.FULL)
+    @SchedulerSupport(SchedulerSupport.NONE)
+    fun <T1 : Any, T2 : Any, T3 : Any, T4 : Any, T5 : Any, T6 : Any, R : Any> combineLatest(
+            source1: Flowable<T1>,
+            source2: Flowable<T2>,
+            source3: Flowable<T3>,
+            source4: Flowable<T4>,
+            source5: Flowable<T5>,
+            source6: Flowable<T6>,
+            bufferSize: Int,
+            combineFunction: (T1, T2, T3, T4, T5, T6) -> R
+    ): Flowable<R> = Flowable.combineLatest(listOf(source1, source2, source3, source4, source5, source6),
+            Functions.toFunction(combineFunction), bufferSize)
+
+
+    @Deprecated("New type inference algorithm in Kotlin 1.4 makes this method obsolete. Method will be removed in future RxKotlin release.",
+            replaceWith = ReplaceWith("Flowable.combineLatest(source1, source2, source3, source4, source5, source6, source7, combineFunction)", "io.reactivex.Flowable"),
+            level = DeprecationLevel.WARNING)
+    @CheckReturnValue
+    @BackpressureSupport(BackpressureKind.FULL)
+    @SchedulerSupport(SchedulerSupport.NONE)
+    fun <T1 : Any, T2 : Any, T3 : Any, T4 : Any, T5 : Any, T6 : Any, T7 : Any, R : Any> combineLatest(
+            source1: Flowable<T1>,
+            source2: Flowable<T2>,
+            source3: Flowable<T3>,
+            source4: Flowable<T4>,
+            source5: Flowable<T5>,
+            source6: Flowable<T6>,
+            source7: Flowable<T7>,
+            bufferSize: Int,
+            combineFunction: (T1, T2, T3, T4, T5, T6, T7) -> R
+    ): Flowable<R> = Flowable.combineLatest(listOf(source1, source2, source3, source4, source5, source6, source7),
+            Functions.toFunction(combineFunction), bufferSize)
 
     @CheckReturnValue
     @BackpressureSupport(BackpressureKind.FULL)
@@ -139,6 +253,27 @@ object Flowables {
     @CheckReturnValue
     @BackpressureSupport(BackpressureKind.FULL)
     @SchedulerSupport(SchedulerSupport.NONE)
+    fun <T1 : Any, T2 : Any, T3 : Any, T4 : Any, T5 : Any, T6 : Any, T7 : Any, T8 : Any, R : Any> combineLatest(
+            source1: Flowable<T1>,
+            source2: Flowable<T2>,
+            source3: Flowable<T3>,
+            source4: Flowable<T4>,
+            source5: Flowable<T5>,
+            source6: Flowable<T6>,
+            source7: Flowable<T7>,
+            source8: Flowable<T8>,
+            bufferSize: Int,
+            combineFunction: (T1, T2, T3, T4, T5, T6, T7, T8) -> R
+    ): Flowable<R> = Flowable.combineLatest(listOf(source1, source2, source3, source4, source5, source6, source7, source8),
+            Functions.toFunction(combineFunction), bufferSize)
+
+
+    @Deprecated("New type inference algorithm in Kotlin 1.4 makes this method obsolete. Method will be removed in future RxKotlin release.",
+            replaceWith = ReplaceWith("Flowable.combineLatest(source1, source2, source3, source4, source5, source6, source7, source8, source9, combineFunction)", "io.reactivex.Flowable"),
+            level = DeprecationLevel.WARNING)
+    @CheckReturnValue
+    @BackpressureSupport(BackpressureKind.FULL)
+    @SchedulerSupport(SchedulerSupport.NONE)
     inline fun <T1 : Any, T2 : Any, T3 : Any, T4 : Any, T5 : Any, T6 : Any, T7 : Any, T8 : Any, T9 : Any, R : Any> combineLatest(
             source1: Flowable<T1>,
             source2: Flowable<T2>,
@@ -152,6 +287,24 @@ object Flowables {
             crossinline combineFunction: (T1, T2, T3, T4, T5, T6, T7, T8, T9) -> R
     ): Flowable<R> = Flowable.combineLatest(source1, source2, source3, source4, source5, source6, source7, source8, source9,
             Function9 { t1: T1, t2: T2, t3: T3, t4: T4, t5: T5, t6: T6, t7: T7, t8: T8, t9: T9 -> combineFunction(t1, t2, t3, t4, t5, t6, t7, t8, t9) })
+
+    @CheckReturnValue
+    @BackpressureSupport(BackpressureKind.FULL)
+    @SchedulerSupport(SchedulerSupport.NONE)
+    fun <T1 : Any, T2 : Any, T3 : Any, T4 : Any, T5 : Any, T6 : Any, T7 : Any, T8 : Any, T9 : Any, R : Any> combineLatest(
+            source1: Flowable<T1>,
+            source2: Flowable<T2>,
+            source3: Flowable<T3>,
+            source4: Flowable<T4>,
+            source5: Flowable<T5>,
+            source6: Flowable<T6>,
+            source7: Flowable<T7>,
+            source8: Flowable<T8>,
+            source9: Flowable<T9>,
+            bufferSize: Int,
+            combineFunction: (T1, T2, T3, T4, T5, T6, T7, T8, T9) -> R
+    ): Flowable<R> = Flowable.combineLatest(listOf(source1, source2, source3, source4, source5, source6, source7, source8, source9),
+            Functions.toFunction(combineFunction), bufferSize)
 
 
     @CheckReturnValue
@@ -173,6 +326,19 @@ object Flowables {
     ): Flowable<R> = Flowable.zip(source1, source2,
             BiFunction<T1, T2, R> { t1, t2 -> combineFunction(t1, t2) })
 
+    @CheckReturnValue
+    @BackpressureSupport(BackpressureKind.FULL)
+    @SchedulerSupport(SchedulerSupport.NONE)
+    inline fun <T1 : Any, T2 : Any, R : Any> zip(
+            source1: Flowable<T1>,
+            source2: Flowable<T2>,
+            delayError: Boolean = false,
+            bufferSize: Int = Flowable.bufferSize(),
+            crossinline combineFunction: (T1, T2) -> R
+    ): Flowable<R> = Flowable.zip(source1, source2,
+            BiFunction<T1, T2, R> { t1, t2 -> combineFunction(t1, t2) }, delayError, bufferSize)
+
+
     /**
      * Emits `Pair<T1,T2>`
      */
@@ -181,6 +347,19 @@ object Flowables {
     @SchedulerSupport(SchedulerSupport.NONE)
     fun <T1 : Any, T2 : Any> zip(source1: Flowable<T1>, source2: Flowable<T2>): Flowable<Pair<T1, T2>> =
             Flowable.zip(source1, source2, BiFunction<T1, T2, Pair<T1, T2>> { t1, t2 -> t1 to t2 })
+
+    /**
+     * Emits `Pair<T1,T2>`
+     */
+    @CheckReturnValue
+    @BackpressureSupport(BackpressureKind.FULL)
+    @SchedulerSupport(SchedulerSupport.NONE)
+    fun <T1 : Any, T2 : Any> zip(
+            source1: Flowable<T1>,
+            source2: Flowable<T2>,
+            delayError: Boolean = false,
+            bufferSize: Int = Flowable.bufferSize()
+    ): Flowable<Pair<T1, T2>> = zip(source1, source2, delayError, bufferSize, ::Pair)
 
 
     @CheckReturnValue
@@ -193,6 +372,16 @@ object Flowables {
             crossinline combineFunction: (T1, T2, T3) -> R
     ): Flowable<R> = Flowable.zip(source1, source2, source3,
             Function3 { t1: T1, t2: T2, t3: T3 -> combineFunction(t1, t2, t3) })
+
+    fun <T1 : Any, T2 : Any, T3 : Any, R : Any> zip(
+            source1: Flowable<T1>,
+            source2: Flowable<T2>,
+            source3: Flowable<T3>,
+            delayError: Boolean = false,
+            bufferSize: Int = Flowable.bufferSize(),
+            combineFunction: (T1, T2, T3) -> R
+    ): Flowable<R> = Flowable.zipIterable(listOf(source1, source2, source3),
+            Functions.toFunction(combineFunction), delayError, bufferSize)
 
     /**
      * Emits `Triple<T1,T2,T3>`
@@ -207,6 +396,24 @@ object Flowables {
     ): Flowable<Triple<T1, T2, T3>> = Flowable.zip(source1, source2, source3,
             Function3<T1, T2, T3, Triple<T1, T2, T3>> { t1, t2, t3 -> Triple(t1, t2, t3) })
 
+    /**
+     * Emits `Triple<T1,T2,T3>`
+     */
+    @CheckReturnValue
+    @BackpressureSupport(BackpressureKind.FULL)
+    @SchedulerSupport(SchedulerSupport.NONE)
+    fun <T1 : Any, T2 : Any, T3 : Any> zip(
+            source1: Flowable<T1>,
+            source2: Flowable<T2>,
+            source3: Flowable<T3>,
+            delayError: Boolean = false,
+            bufferSize: Int = Flowable.bufferSize()
+    ): Flowable<Triple<T1, T2, T3>> = zip(source1, source2, source3, delayError, bufferSize, ::Triple)
+
+
+    @Deprecated("New type inference algorithm in Kotlin 1.4 makes this method obsolete. Method will be removed in future RxKotlin release.",
+            replaceWith = ReplaceWith("Flowable.zip(source1, source2, source3, source4, combineFunction)", "io.reactivex.Flowable"),
+            level = DeprecationLevel.WARNING)
     @CheckReturnValue
     @BackpressureSupport(BackpressureKind.FULL)
     @SchedulerSupport(SchedulerSupport.NONE)
@@ -222,12 +429,40 @@ object Flowables {
     @CheckReturnValue
     @BackpressureSupport(BackpressureKind.FULL)
     @SchedulerSupport(SchedulerSupport.NONE)
+    fun <T1 : Any, T2 : Any, T3 : Any, T4 : Any, R : Any> zip(
+            source1: Flowable<T1>,
+            source2: Flowable<T2>,
+            source3: Flowable<T3>,
+            source4: Flowable<T4>,
+            delayError: Boolean = false,
+            bufferSize: Int = Flowable.bufferSize(),
+            combineFunction: (T1, T2, T3, T4) -> R
+    ): Flowable<R> = Flowable.zipIterable(listOf(source1, source2, source3, source4),
+            Functions.toFunction(combineFunction), delayError, bufferSize)
+
+
+    @Deprecated("New type inference algorithm in Kotlin 1.4 makes this method obsolete. Method will be removed in future RxKotlin release.",
+            replaceWith = ReplaceWith("Flowable.zip(source1, source2, source3, source4, source5, combineFunction)", "io.reactivex.Flowable"),
+            level = DeprecationLevel.WARNING)
+    @CheckReturnValue
+    @BackpressureSupport(BackpressureKind.FULL)
+    @SchedulerSupport(SchedulerSupport.NONE)
     inline fun <T1 : Any, T2 : Any, T3 : Any, T4 : Any, T5 : Any, R : Any> zip(
             source1: Flowable<T1>, source2: Flowable<T2>,
             source3: Flowable<T3>, source4: Flowable<T4>,
             source5: Flowable<T5>, crossinline combineFunction: (T1, T2, T3, T4, T5) -> R
     ): Flowable<R> = Flowable.zip(source1, source2, source3, source4, source5,
             Function5 { t1: T1, t2: T2, t3: T3, t4: T4, t5: T5 -> combineFunction(t1, t2, t3, t4, t5) })
+
+    fun <T1 : Any, T2 : Any, T3 : Any, T4 : Any, T5 : Any, R : Any> zip(
+            source1: Flowable<T1>, source2: Flowable<T2>,
+            source3: Flowable<T3>, source4: Flowable<T4>,
+            source5: Flowable<T5>,
+            delayError: Boolean = false,
+            bufferSize: Int = Flowable.bufferSize(),
+            combineFunction: (T1, T2, T3, T4, T5) -> R
+    ): Flowable<R> = Flowable.zipIterable(listOf(source1, source2, source3, source4, source5),
+            Functions.toFunction(combineFunction), delayError, bufferSize)
 
 
     @CheckReturnValue
@@ -243,6 +478,23 @@ object Flowables {
     @CheckReturnValue
     @BackpressureSupport(BackpressureKind.FULL)
     @SchedulerSupport(SchedulerSupport.NONE)
+    fun <T1 : Any, T2 : Any, T3 : Any, T4 : Any, T5 : Any, T6 : Any, R : Any> zip(
+            source1: Flowable<T1>, source2: Flowable<T2>,
+            source3: Flowable<T3>, source4: Flowable<T4>,
+            source5: Flowable<T5>, source6: Flowable<T6>,
+            delayError: Boolean = false,
+            bufferSize: Int = Flowable.bufferSize(),
+            combineFunction: (T1, T2, T3, T4, T5, T6) -> R
+    ): Flowable<R> = Flowable.zipIterable(listOf(source1, source2, source3, source4, source5, source6),
+            Functions.toFunction(combineFunction), delayError, bufferSize)
+
+
+    @Deprecated("New type inference algorithm in Kotlin 1.4 makes this method obsolete. Method will be removed in future RxKotlin release.",
+            replaceWith = ReplaceWith("Flowable.zip(source1, source2, source3, source4, source5, source6, source7, combineFunction)", "io.reactivex.Flowable"),
+            level = DeprecationLevel.WARNING)
+    @CheckReturnValue
+    @BackpressureSupport(BackpressureKind.FULL)
+    @SchedulerSupport(SchedulerSupport.NONE)
     inline fun <T1 : Any, T2 : Any, T3 : Any, T4 : Any, T5 : Any, T6 : Any, T7 : Any, R : Any> zip(
             source1: Flowable<T1>, source2: Flowable<T2>,
             source3: Flowable<T3>, source4: Flowable<T4>,
@@ -250,6 +502,20 @@ object Flowables {
             source7: Flowable<T7>, crossinline combineFunction: (T1, T2, T3, T4, T5, T6, T7) -> R
     ): Flowable<R> = Flowable.zip(source1, source2, source3, source4, source5, source6, source7,
             Function7 { t1: T1, t2: T2, t3: T3, t4: T4, t5: T5, t6: T6, t7: T7 -> combineFunction(t1, t2, t3, t4, t5, t6, t7) })
+
+    @CheckReturnValue
+    @BackpressureSupport(BackpressureKind.FULL)
+    @SchedulerSupport(SchedulerSupport.NONE)
+    fun <T1 : Any, T2 : Any, T3 : Any, T4 : Any, T5 : Any, T6 : Any, T7 : Any, R : Any> zip(
+            source1: Flowable<T1>, source2: Flowable<T2>,
+            source3: Flowable<T3>, source4: Flowable<T4>,
+            source5: Flowable<T5>, source6: Flowable<T6>,
+            source7: Flowable<T7>,
+            delayError: Boolean = false,
+            bufferSize: Int = Flowable.bufferSize(),
+            combineFunction: (T1, T2, T3, T4, T5, T6, T7) -> R
+    ): Flowable<R> = Flowable.zipIterable(listOf(source1, source2, source3, source4, source5, source6, source7),
+            Functions.toFunction(combineFunction), delayError, bufferSize)
 
 
     @CheckReturnValue
@@ -267,6 +533,23 @@ object Flowables {
     @CheckReturnValue
     @BackpressureSupport(BackpressureKind.FULL)
     @SchedulerSupport(SchedulerSupport.NONE)
+    fun <T1 : Any, T2 : Any, T3 : Any, T4 : Any, T5 : Any, T6 : Any, T7 : Any, T8 : Any, R : Any> zip(
+            source1: Flowable<T1>, source2: Flowable<T2>,
+            source3: Flowable<T3>, source4: Flowable<T4>,
+            source5: Flowable<T5>, source6: Flowable<T6>,
+            source7: Flowable<T7>, source8: Flowable<T8>,
+            delayError: Boolean = false,
+            bufferSize: Int = Flowable.bufferSize(),
+            combineFunction: (T1, T2, T3, T4, T5, T6, T7, T8) -> R
+    ): Flowable<R> = Flowable.zipIterable(listOf(source1, source2, source3, source4, source5, source6, source7, source8),
+            Functions.toFunction(combineFunction), delayError, bufferSize)
+
+    @Deprecated("New type inference algorithm in Kotlin 1.4 makes this method obsolete. Method will be removed in future RxKotlin release.",
+            replaceWith = ReplaceWith("Flowable.zip(source1, source2, source3, source4, source5, source6, source7, source8, source9, combineFunction)", "io.reactivex.Flowable"),
+            level = DeprecationLevel.WARNING)
+    @CheckReturnValue
+    @BackpressureSupport(BackpressureKind.FULL)
+    @SchedulerSupport(SchedulerSupport.NONE)
     inline fun <T1 : Any, T2 : Any, T3 : Any, T4 : Any, T5 : Any, T6 : Any, T7 : Any, T8 : Any, T9 : Any, R : Any> zip(
             source1: Flowable<T1>,
             source2: Flowable<T2>,
@@ -280,6 +563,25 @@ object Flowables {
             crossinline combineFunction: (T1, T2, T3, T4, T5, T6, T7, T8, T9) -> R
     ): Flowable<R> = Flowable.zip(source1, source2, source3, source4, source5, source6, source7, source8, source9,
             Function9 { t1: T1, t2: T2, t3: T3, t4: T4, t5: T5, t6: T6, t7: T7, t8: T8, t9: T9 -> combineFunction(t1, t2, t3, t4, t5, t6, t7, t8, t9) })
+
+    @CheckReturnValue
+    @BackpressureSupport(BackpressureKind.FULL)
+    @SchedulerSupport(SchedulerSupport.NONE)
+    fun <T1 : Any, T2 : Any, T3 : Any, T4 : Any, T5 : Any, T6 : Any, T7 : Any, T8 : Any, T9 : Any, R : Any> zip(
+            source1: Flowable<T1>,
+            source2: Flowable<T2>,
+            source3: Flowable<T3>,
+            source4: Flowable<T4>,
+            source5: Flowable<T5>,
+            source6: Flowable<T6>,
+            source7: Flowable<T7>,
+            source8: Flowable<T8>,
+            source9: Flowable<T9>,
+            delayError: Boolean = false,
+            bufferSize: Int = Flowable.bufferSize(),
+            combineFunction: (T1, T2, T3, T4, T5, T6, T7, T8, T9) -> R
+    ): Flowable<R> = Flowable.zipIterable(listOf(source1, source2, source3, source4, source5, source6, source7, source8, source9),
+            Functions.toFunction(combineFunction), delayError, bufferSize)
 
 }
 


### PR DESCRIPTION
(This is PR #242 based on RxKotlin 2.x)

This PR adds new functions to `Flowables `:
- `Flowables.combineLatest` variants that take `bufferSize` parameter
- `Flowables.zip` variants that take `delayError` and `bufferSize` parameters

The parameters have been rearranged to make use of default parameter values and lambda syntax.

Usage example:
```kotlin
Flowables.combineLatest(Flowable.just(1), Flowable.just(2), bufferSize = 4) { i1, i2 -> i1 + i2 }
```